### PR TITLE
moved max,min,avg class methods to pr, and added intance methods to url

### DIFF
--- a/app/models/payload_request.rb
+++ b/app/models/payload_request.rb
@@ -31,4 +31,17 @@ class PayloadRequest < ActiveRecord::Base
       UserAgent.find(id).os
     end
   end
+
+  def self.max_response
+    PayloadRequest.maximum(:responded_in)
+  end
+
+  def self.min_response
+    PayloadRequest.minimum(:responded_in)
+  end
+
+  def self.average_response
+    PayloadRequest.average(:responded_in)
+  end
+
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -36,16 +36,18 @@ class Url < ActiveRecord::Base
     end
   end
 
-  def self.max_response
-    PayloadRequest.maximum(:responded_in)
+
+
+  def max_response_for_url
+    payload_requests.maximum(:responded_in)
   end
 
-  def self.min_response
-    PayloadRequest.minimum(:responded_in)
+  def min_response_for_url
+    payload_requests.minimum(:responded_in)
   end
 
-  def self.average_response
-    PayloadRequest.average(:responded_in)
+  def average_response_for_url
+    payload_requests.average(:responded_in)
   end
 
 end

--- a/test/models/payload_request_test.rb
+++ b/test/models/payload_request_test.rb
@@ -135,5 +135,34 @@ class PayloadRequestTest < Minitest::Test
     assert_equal ["Macintosh", "Windows"], PayloadRequest.os_breakdown
   end
 
+  def test_it_can_find_calculate_response_time_stats_for_all_urls
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                               responded_in: 100,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 1)
+
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                               responded_in: 20,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 2)
+
+    assert_equal 2, PayloadRequest.count
+    assert_equal 100, PayloadRequest.max_response
+    assert_equal 20, PayloadRequest.min_response
+    assert_equal 60, PayloadRequest.average_response
+  end
+
 
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -453,14 +453,14 @@ class UrlTest < Minitest::Test
     assert_equal ["Windows Chrome", "Macintosh Safari", "Linux Internet Explorer"], url.popular_agents
   end
 
-  def test_it_can_find_calculate_response_time_stats
+  def test_it_can_find_calculate_response_time_stats_for_one_url
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                                responded_in: 100,
                                referrer_id: 1,
-                               request_type_id: 1, 
+                               request_type_id: 1,
                                parameters: "[]",
                                event_name_id: 1,
-                               user_agent_id: 1, 
+                               user_agent_id: 1,
                                resolution_id: 1,
                                ip_id: 1,
                                url_id: 1)
@@ -468,19 +468,28 @@ class UrlTest < Minitest::Test
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                                responded_in: 20,
                                referrer_id: 1,
-                               request_type_id: 1, 
+                               request_type_id: 1,
                                parameters: "[]",
                                event_name_id: 1,
-                               user_agent_id: 1, 
+                               user_agent_id: 1,
                                resolution_id: 1,
                                ip_id: 1,
                                url_id: 1)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                               responded_in: 2000,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 2)
 
-    assert_equal 2, PayloadRequest.count
-    Url.create(address: "www.turing.com")
-    assert_equal 100, Url.max_response
-    assert_equal 20, Url.min_response
-    assert_equal 60, Url.average_response
+    url = Url.create(address: "www.turing.com")
+    assert_equal 100, url.max_response_for_url
+    assert_equal 20, url.min_response_for_url
+    assert_equal 60, url.average_response_for_url
   end
 
 end


### PR DESCRIPTION
Hi again,
I moved the class methods for max, min, and average response times to be class methods on payload_requests, rather than URL.  Then, I added in the url instance methods for the same.

Kerry  
