### PR TITLE
test payload parsing of parameters, and ensure writing to db (fixes issue #45)

### DIFF
--- a/app/models/payload_parser.rb
+++ b/app/models/payload_parser.rb
@@ -8,6 +8,7 @@ module PayloadParser
     result = {}
     result[:requested_at] = raw_payload["requestedAt"]
     result[:responded_in] = raw_payload["respondedIn"]
+    result[:parameters] = raw_payload["parameters"]
     result[:referrer] = { address: raw_payload["referredBy"] }
     result[:request_type] = { verb: raw_payload["requestType"] }
     result[:event_name] = { name: raw_payload["eventName"] }

--- a/app/models/payload_request.rb
+++ b/app/models/payload_request.rb
@@ -4,6 +4,7 @@ class PayloadRequest < ActiveRecord::Base
   validates :url_id, presence: true
   validates :requested_at, presence: true
   validates :responded_in, presence: true
+  validates :parameters, presence: true
   validates :referrer_id, presence: true
   validates :event_name_id, presence: true
   validates :request_type_id, presence: true
@@ -77,7 +78,7 @@ class PayloadRequest < ActiveRecord::Base
     pr.ip = Ip.find_or_create_by(payload[:ip])
     pr.url = Url.find_or_create_by(payload[:url])
     pr.client = client
-    pr.parameters = "[]"
+    pr.parameters = payload[:parameters]
     pr.key = PayloadParser.generate_sha(inclusive_payload)
     pr.save
   end

--- a/test/models/payload_parser_test.rb
+++ b/test/models/payload_parser_test.rb
@@ -3,14 +3,14 @@ require_relative '../test_helper'
 class PayloadParserTest < Minitest::Test
 
   def test_convert_json_to_hash
-    raw_json = '{"url":"http://jumpstartlab.com/blog","requestedAt":"2013-02-16 21:38:28 -0700","respondedIn":37,"referredBy":"http://jumpstartlab.com","requestType":"GET","parameters":[],"eventName": "socialLogin","userAgent":"Mozilla/5.0 (Macintosh%3b Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17","resolutionWidth":"1920","resolutionHeight":"1280","ip":"63.29.38.211"}'
+    raw_json = '{"url":"http://jumpstartlab.com/blog","requestedAt":"2013-02-16 21:38:28 -0700","respondedIn":37,"referredBy":"http://jumpstartlab.com","requestType":"GET","parameters":["what", "huh"],"eventName": "socialLogin","userAgent":"Mozilla/5.0 (Macintosh%3b Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17","resolutionWidth":"1920","resolutionHeight":"1280","ip":"63.29.38.211"}'
     result = JSON.parse(raw_json)
     expected = {"url"=>"http://jumpstartlab.com/blog",
                 "requestedAt"=>"2013-02-16 21:38:28 -0700",
                 "respondedIn"=>37,
                 "referredBy"=>"http://jumpstartlab.com",
                 "requestType"=>"GET",
-                "parameters"=>[],
+                "parameters"=>["what","huh"],
                 "eventName"=>"socialLogin",
                 "userAgent"=>"Mozilla/5.0 (Macintosh%3b Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17",
                 "resolutionWidth"=>"1920",
@@ -21,21 +21,23 @@ class PayloadParserTest < Minitest::Test
   end
 
   def test_we_can_parse_json
-    raw_json = '{"url":"http://jumpstartlab.com/blog","requestedAt":"2013-02-16 21:38:28 -0700","respondedIn":37,"referredBy":"http://jumpstartlab.com","requestType":"GET","parameters":[],"eventName": "socialLogin","userAgent":"Mozilla/5.0 (Macintosh%3B Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17","resolutionWidth":"1920","resolutionHeight":"1280","ip":"63.29.38.211"}'
+    raw_json = '{"url":"http://jumpstartlab.com/blog","requestedAt":"2013-02-16 21:38:28 -0700","respondedIn":37,"referredBy":"http://jumpstartlab.com","requestType":"GET","parameters":["what","huh"],"eventName": "socialLogin","userAgent":"Mozilla/5.0 (Macintosh%3B Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17","resolutionWidth":"1920","resolutionHeight":"1280","ip":"63.29.38.211"}'
     result = PayloadParser.parse_json(raw_json)
 
     expected = {requested_at: "2013-02-16 21:38:28 -0700",
-              responded_in: 37,
-                  referrer: { address: "http://jumpstartlab.com" },
-              request_type: { verb: "GET" },
-                event_name: { name: "socialLogin" },
-                resolution: { width: "1920", height: "1280" },
-                user_agent: { os: "Mac OS X 10.8.2", browser: "Chrome 24.0.1309" },
-                        ip: { address: "63.29.38.211" },
-                       url: { address: "http://jumpstartlab.com/blog"}}
+                responded_in: 37,
+                  parameters: ["what","huh"],
+                    referrer: { address: "http://jumpstartlab.com" },
+                request_type: { verb: "GET" },
+                  event_name: { name: "socialLogin" },
+                  resolution: { width: "1920", height: "1280" },
+                  user_agent: { os: "Mac OS X 10.8.2", browser: "Chrome 24.0.1309" },
+                          ip: { address: "63.29.38.211" },
+                         url: { address: "http://jumpstartlab.com/blog"}}
 
     assert_equal expected[:requested_at], result[:requested_at]
     assert_equal expected[:responded_in], result[:responded_in]
+    assert_equal expected[:parameters], result[:parameters]
     assert_equal expected[:referrer], result[:referrer]
     assert_equal expected[:request_type], result[:request_type]
     assert_equal expected[:event_name], result[:event_name]
@@ -45,3 +47,4 @@ class PayloadParserTest < Minitest::Test
     assert_equal expected[:url], result[:url]
   end
 end
+

--- a/test/models/payload_request_test.rb
+++ b/test/models/payload_request_test.rb
@@ -102,7 +102,7 @@ class PayloadRequestTest < Minitest::Test
 
   def test_it_rejects_payload_request_with_missing_data
     pr = PayloadRequest.create
-    assert_equal 9, pr.errors.messages.length
+    assert_equal 10, pr.errors.messages.length
     assert_equal true, pr.invalid?
     # assert_equal true, pr.errors.messages.keys.sort(:url)
   end


### PR DESCRIPTION
Fixes issue #45 : added ability to write 'parameters' attribute from raw JSON into the tables. previously, we were hard-coding [] into the tables.

