### PR TITLE
Add client and key validations (closes issue #40)

### DIFF
--- a/app/models/payload_request.rb
+++ b/app/models/payload_request.rb
@@ -10,8 +10,8 @@ class PayloadRequest < ActiveRecord::Base
   validates :resolution_id, presence: true
   validates :user_agent_id, presence: true
   validates :ip_id, presence: true
-  # validates :client_id, presence: true
-  # validates :key, presence: true
+  validates :client_id, presence: true
+  validates :key, presence: true
 
   belongs_to :url
   belongs_to :event_name

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -14,7 +14,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -25,7 +25,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -36,7 +36,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
     c1 = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     Client.create(identifier: "KingSoopers", root_url: "www.KingSoopers.com")
     url = Url.create(address: "www.BestBuy.com/cameras")
@@ -57,7 +57,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -68,7 +68,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -79,7 +79,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     assert_equal 49, client.average_response_time_for_client
@@ -98,7 +98,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -109,7 +109,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -120,7 +120,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     assert_equal 48, client.min_response_time_for_client
@@ -139,7 +139,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -150,7 +150,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -161,7 +161,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     assert_equal 50, client.max_response_time_for_client
@@ -180,7 +180,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -191,7 +191,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -202,7 +202,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -213,7 +213,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     req1 = RequestType.create(verb: "GET")
@@ -234,7 +234,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -245,7 +245,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -256,7 +256,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -267,7 +267,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     req1 = RequestType.create(verb: "GET")
@@ -278,282 +278,279 @@ class ClientTest < Minitest::Test
   end
 
   def test_it_lists_all_resoultions_for_client
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 48,
-                            referrer_id: 1,
-                            request_type_id: 1,
-                            parameters: "[]",
-                            event_name_id: 1,
-                            resolution_id: 1,
-                            user_agent_id: 1,
-                            ip_id: 1,
-                            url_id: 1,
-                            client_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 50,
-                            referrer_id: 1,
-                            request_type_id: 2,
-                            parameters: "[]",
-                            event_name_id: 1,
-                            resolution_id: 2,
-                            user_agent_id: 1,
-                            ip_id: 1,
-                            url_id: 1,
-                            client_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 50,
-                            referrer_id: 1,
-                            request_type_id: 2,
-                            parameters: "[]",
-                            event_name_id: 1,
-                            resolution_id: 3,
-                            user_agent_id: 1,
-                            ip_id: 1,
-                            url_id: 1,
-                            client_id: 1)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 2,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
 
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 50,
-                            referrer_id: 1,
-                            request_type_id: 2,
-                            parameters: "[]",
-                            event_name_id: 1,
-                            resolution_id: 3,
-                            user_agent_id: 1,
-                            ip_id: 1,
-                            url_id: 1,
-                            client_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 100,
-                            referrer_id: 1,
-                            request_type_id: 1,
-                            parameters: "[]",
-                            event_name_id: 1,
-                            resolution_id: 4,
-                            user_agent_id: 1,
-                            ip_id: 1,
-                            url_id: 1,
-                            client_id: 2)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 100,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 4,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 2, key: "SHA-1")
 
-      client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-      Resolution.create(height: '1', width: '1')
-      Resolution.create(height: '2', width: '1')
-      Resolution.create(height: '3', width: '1')
-      Resolution.create(height: '4', width: '1')
+    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
+    Resolution.create(height: '1', width: '1')
+    Resolution.create(height: '2', width: '1')
+    Resolution.create(height: '3', width: '1')
+    Resolution.create(height: '4', width: '1')
 
-      assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 1")
-      assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 2")
-      assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 3")
-      assert_equal false, client.all_screen_resolutions_for_client.include?("1 x 4")
-      assert_equal ["1 x 1", "1 x 2", "1 x 3"], client.all_screen_resolutions_for_client.uniq.sort
+    assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 1")
+    assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 2")
+    assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 3")
+    assert_equal false, client.all_screen_resolutions_for_client.include?("1 x 4")
+    assert_equal ["1 x 1", "1 x 2", "1 x 3"], client.all_screen_resolutions_for_client.uniq.sort
 
+  end
 
-    end
+  def test_it_provides_breakdown_of_all_browswers_for_client
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 2,
+                          user_agent_id: 2,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
 
-    def test_it_provides_breakdown_of_all_browswers_for_client
-        PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                              responded_in: 48,
-                              referrer_id: 1,
-                              request_type_id: 1,
-                              parameters: "[]",
-                              event_name_id: 1,
-                              resolution_id: 1,
-                              user_agent_id: 1,
-                              ip_id: 1,
-                              url_id: 1,
-                              client_id: 1)
-        PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                              responded_in: 50,
-                              referrer_id: 1,
-                              request_type_id: 2,
-                              parameters: "[]",
-                              event_name_id: 1,
-                              resolution_id: 2,
-                              user_agent_id: 2,
-                              ip_id: 1,
-                              url_id: 1,
-                              client_id: 1)
-        PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                              responded_in: 50,
-                              referrer_id: 1,
-                              request_type_id: 2,
-                              parameters: "[]",
-                              event_name_id: 1,
-                              resolution_id: 3,
-                              user_agent_id: 1,
-                              ip_id: 1,
-                              url_id: 1,
-                              client_id: 1)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 100,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 4,
+                          user_agent_id: 3,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 2, key: "SHA-1")
 
-        PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                              responded_in: 50,
-                              referrer_id: 1,
-                              request_type_id: 2,
-                              parameters: "[]",
-                              event_name_id: 1,
-                              resolution_id: 3,
-                              user_agent_id: 1,
-                              ip_id: 1,
-                              url_id: 1,
-                              client_id: 1)
-        PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                              responded_in: 100,
-                              referrer_id: 1,
-                              request_type_id: 1,
-                              parameters: "[]",
-                              event_name_id: 1,
-                              resolution_id: 4,
-                              user_agent_id: 3,
-                              ip_id: 1,
-                              url_id: 1,
-                              client_id: 2)
+    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
+    UserAgent.create(browser: 'IE', os: 'Windows')
+    UserAgent.create(browser: 'Chrome', os: 'Windows')
+    UserAgent.create(browser: 'Firefox', os: 'Windows')
 
-        client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-        UserAgent.create(browser: 'IE', os: 'Windows')
-        UserAgent.create(browser: 'Chrome', os: 'Windows')
-        UserAgent.create(browser: 'Firefox', os: 'Windows')
-
-        expected = {"IE" => 3, "Chrome" => 1}
-        assert_equal expected, client.browser_breakdown_for_client
-
-
-      end
-
-      def test_it_provides_breakdown_of_all_operating_systems_for_client
-          PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                responded_in: 48,
-                                referrer_id: 1,
-                                request_type_id: 1,
-                                parameters: "[]",
-                                event_name_id: 1,
-                                resolution_id: 1,
-                                user_agent_id: 1,
-                                ip_id: 1,
-                                url_id: 1,
-                                client_id: 1)
-          PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                responded_in: 50,
-                                referrer_id: 1,
-                                request_type_id: 2,
-                                parameters: "[]",
-                                event_name_id: 1,
-                                resolution_id: 2,
-                                user_agent_id: 2,
-                                ip_id: 1,
-                                url_id: 1,
-                                client_id: 1)
-          PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                responded_in: 50,
-                                referrer_id: 1,
-                                request_type_id: 2,
-                                parameters: "[]",
-                                event_name_id: 1,
-                                resolution_id: 3,
-                                user_agent_id: 1,
-                                ip_id: 1,
-                                url_id: 1,
-                                client_id: 1)
-
-          PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                responded_in: 50,
-                                referrer_id: 1,
-                                request_type_id: 2,
-                                parameters: "[]",
-                                event_name_id: 1,
-                                resolution_id: 3,
-                                user_agent_id: 1,
-                                ip_id: 1,
-                                url_id: 1,
-                                client_id: 1)
-          PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                responded_in: 100,
-                                referrer_id: 1,
-                                request_type_id: 1,
-                                parameters: "[]",
-                                event_name_id: 1,
-                                resolution_id: 4,
-                                user_agent_id: 3,
-                                ip_id: 1,
-                                url_id: 1,
-                                client_id: 2)
-
-          client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-          UserAgent.create(browser: 'IE', os: 'Windows')
-          UserAgent.create(browser: 'Chrome', os: 'OSX')
-          UserAgent.create(browser: 'Firefox', os: 'Linux')
-          expected = {"Windows" => 3, "OSX" => 1}
-
-          assert_equal expected, client.operating_system_breakdown_for_client
+    expected = {"IE" => 3, "Chrome" => 1}
+    assert_equal expected, client.browser_breakdown_for_client
+  end
 
 
-        end
+  def test_it_provides_breakdown_of_all_operating_systems_for_client
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 2,
+                          user_agent_id: 2,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
 
-        def test_it_lists_all_urls_by_requests_for_client
-            PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                  responded_in: 48,
-                                  referrer_id: 1,
-                                  request_type_id: 1,
-                                  parameters: "[]",
-                                  event_name_id: 1,
-                                  resolution_id: 1,
-                                  user_agent_id: 1,
-                                  ip_id: 1,
-                                  url_id: 1,
-                                  client_id: 1)
-            PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                  responded_in: 50,
-                                  referrer_id: 1,
-                                  request_type_id: 2,
-                                  parameters: "[]",
-                                  event_name_id: 1,
-                                  resolution_id: 2,
-                                  user_agent_id: 2,
-                                  ip_id: 1,
-                                  url_id: 3,
-                                  client_id: 1)
-            PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                  responded_in: 50,
-                                  referrer_id: 1,
-                                  request_type_id: 2,
-                                  parameters: "[]",
-                                  event_name_id: 1,
-                                  resolution_id: 3,
-                                  user_agent_id: 1,
-                                  ip_id: 1,
-                                  url_id: 3,
-                                  client_id: 1)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 100,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 4,
+                          user_agent_id: 3,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 2, key: "SHA-1")
 
-            PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                  responded_in: 50,
-                                  referrer_id: 1,
-                                  request_type_id: 2,
-                                  parameters: "[]",
-                                  event_name_id: 1,
-                                  resolution_id: 3,
-                                  user_agent_id: 1,
-                                  ip_id: 1,
-                                  url_id: 3,
-                                  client_id: 1)
-            PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                                  responded_in: 100,
-                                  referrer_id: 1,
-                                  request_type_id: 1,
-                                  parameters: "[]",
-                                  event_name_id: 1,
-                                  resolution_id: 4,
-                                  user_agent_id: 3,
-                                  ip_id: 1,
-                                  url_id: 1,
-                                  client_id: 2)
+    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
+    UserAgent.create(browser: 'IE', os: 'Windows')
+    UserAgent.create(browser: 'Chrome', os: 'OSX')
+    UserAgent.create(browser: 'Firefox', os: 'Linux')
+    expected = {"Windows" => 3, "OSX" => 1}
 
-            client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-            Url.create(address: "www.test.com")
-            Url.create(address: "www.test.com/list")
-            Url.create(address: "www.test.com/new")
-            expected = ["www.test.com/new", "www.test.com"]
+    assert_equal expected, client.operating_system_breakdown_for_client
 
-            assert_equal expected, client.url_list_ordered_by_request_count
+  end
 
+
+  def test_it_lists_all_urls_by_requests_for_client
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 2,
+                          user_agent_id: 2,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1, key: "SHA-1")
+
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: 2,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 3,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 100,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 4,
+                          user_agent_id: 3,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 2, key: "SHA-1")
+
+    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
+    Url.create(address: "www.test.com")
+    Url.create(address: "www.test.com/list")
+    Url.create(address: "www.test.com/new")
+    expected = ["www.test.com/new", "www.test.com"]
+
+    assert_equal expected, client.url_list_ordered_by_request_count
   end
 
   def test_client_can_return_list_of_relative_paths
@@ -567,7 +564,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -578,7 +575,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 2,
                           ip_id: 1,
                           url_id: 3,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -589,7 +586,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 3,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
@@ -601,7 +598,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 2,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -612,7 +609,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 3,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.test.com")
     Url.create(address: "www.test.com")
@@ -635,7 +632,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -646,7 +643,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 2,
                           ip_id: 1,
                           url_id: 3,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
@@ -657,7 +654,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 3,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
@@ -669,7 +666,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 2,
-                          client_id: 1)
+                          client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -680,7 +677,7 @@ class ClientTest < Minitest::Test
                           user_agent_id: 3,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2)
+                          client_id: 2, key: "SHA-1")
 
     client = Client.create(identifier: "BestBuy", root_url: "www.test.com")
     Url.create(address: "www.test.com")
@@ -698,54 +695,51 @@ class ClientTest < Minitest::Test
 
 
   def test_it_groups_events_by_hour_for_client
-  PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                        responded_in: 48,
-                        referrer_id: 1,
-                        request_type_id: 1,
-                        parameters: "[]",
-                        event_name_id: 1,
-                        resolution_id: 1,
-                        user_agent_id: 1,
-                        ip_id: 1,
-                        url_id: 1,
-                        client_id: 1)
-  PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                        responded_in: 48,
-                        referrer_id: 1,
-                        request_type_id: 1,
-                        parameters: "[]",
-                        event_name_id: 1,
-                        resolution_id: 1,
-                        user_agent_id: 1,
-                        ip_id: 1,
-                        url_id: 1,
-                        client_id: 1)
-  PayloadRequest.create(requested_at: "2013-02-16 20:38:28 -0700",
-                        responded_in: 48,
-                        referrer_id: 1,
-                        request_type_id: 1,
-                        parameters: "[]",
-                        event_name_id: 1,
-                        resolution_id: 1,
-                        user_agent_id: 1,
-                        ip_id: 1,
-                        url_id: 1,
-                        client_id: 1)
-  client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-  event = EventName.create(name: "event1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 20:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
+    event = EventName.create(name: "event1")
+  
+    expected = {21.0 =>2, 20.0 =>1}
+    assert_equal expected, client.event_requests_by_hour("event1")
+  end
 
-  expected = {21.0 =>2, 20.0 =>1}
-  assert_equal expected, client.event_requests_by_hour("event1")
-end
-
-def test_groups_events_by_hour_returns_empty_if_no_requests
-
-  client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-  event = EventName.create(name: "event1")
-
-  assert_equal ({}), client.event_requests_by_hour("event1")
-end
-
-
-
+  def test_groups_events_by_hour_returns_empty_if_no_requests
+  
+    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
+    event = EventName.create(name: "event1")
+  
+    assert_equal ({}), client.event_requests_by_hour("event1")
+  end
 end

--- a/test/models/event_name_test.rb
+++ b/test/models/event_name_test.rb
@@ -18,15 +18,17 @@ class EventNameTest < Minitest::Test
 
   def test_event_name_payload_requests_relationship
     pr = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1)
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               resolution_id: 1,
+                               user_agent_id: 1,
+                               ip_id: 1,
+                               url_id: 1,
+                               client_id: 1,
+                               key: "SHA-1")
 
     event_name = EventName.create(name: "event")
 
@@ -35,15 +37,90 @@ class EventNameTest < Minitest::Test
     assert_equal "event", pr.event_name.name
   end
 
-
-
   def test_it_sorts_by_requested
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 1, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 1)
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 1, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 1)
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 2, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 2)
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 3, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 3)
-    PayloadRequest.create(requested_at: "2014-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 1, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 3)
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 3, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 3)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 2,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 2,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 3,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2014-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 3,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 3,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1,
+                          key: "SHA-1")
 
     EventName.create(name: "event1")
     EventName.create(name: "event2")
@@ -51,11 +128,32 @@ class EventNameTest < Minitest::Test
 
     assert_equal ["event1", "event3", "event2"], EventName.most_to_least_received
 
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 3, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 3)
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",responded_in: 48,  referrer_id: 1, request_type_id: 1, parameters: "[]",event_name_id: 3, user_agent_id: 1, resolution_id: 1, ip_id: 1, url_id: 3)
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 3,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1,
+                          key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 3,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3,
+                          client_id: 1,
+                          key: "SHA-1")
 
     assert_equal ["event3", "event1", "event2"], EventName.most_to_least_received
   end
-
 
 end

--- a/test/models/ip_test.rb
+++ b/test/models/ip_test.rb
@@ -12,15 +12,15 @@ class IpTest < Minitest::Test
   def test_ip_payload_requests_relationship
     ip = Ip.create(address: "127.0.0.1")
     pr = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          user_agent_id: 1,
-                          resolution_id: 1,
-                          ip_id: 1,
-                          url_id: 1)
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 1, client_id: 1, key: "SHA-1")
     assert_equal "127.0.0.1", pr.ip.address
   end
 end

--- a/test/models/payload_parser_test.rb
+++ b/test/models/payload_parser_test.rb
@@ -25,14 +25,14 @@ class PayloadParserTest < Minitest::Test
     result = PayloadParser.parse_json(raw_json)
 
     expected = {requested_at: "2013-02-16 21:38:28 -0700",
-              responded_in: 37,
-                  referrer: { address: "http://jumpstartlab.com" },
-              request_type: { verb: "GET" },
-                event_name: { name: "socialLogin" },
-                resolution: { width: "1920", height: "1280" },
-                user_agent: { os: "Mac OS X 10.8.2", browser: "Chrome 24.0.1309" },
-                        ip: { address: "63.29.38.211" },
-                       url: { address: "http://jumpstartlab.com/blog"}}
+                responded_in: 37,
+                    referrer: { address: "http://jumpstartlab.com" },
+                request_type: { verb: "GET" },
+                  event_name: { name: "socialLogin" },
+                  resolution: { width: "1920", height: "1280" },
+                  user_agent: { os: "Mac OS X 10.8.2", browser: "Chrome 24.0.1309" },
+                          ip: { address: "63.29.38.211" },
+                         url: { address: "http://jumpstartlab.com/blog"}}
 
     assert_equal expected[:requested_at], result[:requested_at]
     assert_equal expected[:responded_in], result[:responded_in]

--- a/test/models/payload_request_test.rb
+++ b/test/models/payload_request_test.rb
@@ -25,7 +25,7 @@ class PayloadRequestTest < Minitest::Test
     assert_equal 1, Referrer.count
     assert_equal 1, Resolution.count
     assert_equal 1, UserAgent.count
-    # assert PayloadRequest.key
+    assert PayloadRequest.first.key
   end
 
   def test_it_handles_similar_payload_requests
@@ -40,7 +40,7 @@ class PayloadRequestTest < Minitest::Test
     assert_equal 1, Referrer.count
     assert_equal 1, Resolution.count
     assert_equal 1, UserAgent.count
-    # assert PayloadRequest.key
+    assert PayloadRequest.first.key
 
   end
 
@@ -54,15 +54,12 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
-    # url = Url.create(address: "www.turing.com")
-    #
-    # url.payload_requests << PayloadRequest.find_by(id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     assert_equal 1, PayloadRequest.count
     assert_equal 1, PayloadRequest.first.id
     assert_equal 48, PayloadRequest.first.responded_in
-    # assert PayloadRequest.key
+    assert "SHA-1", PayloadRequest.first.key
   end
 
   def test_payload_info_stored_in_correct_format
@@ -75,7 +72,7 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     assert_equal Fixnum, PayloadRequest.first.id.class
     assert_equal Time, PayloadRequest.first.requested_at.class
@@ -92,7 +89,7 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           ip_id: 1,
                           user_agent_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     time = Time.new(2013, 02, 16, 21, 38, 28, "-07:00")
 
@@ -102,22 +99,21 @@ class PayloadRequestTest < Minitest::Test
 
   def test_it_rejects_payload_request_with_missing_data
     pr = PayloadRequest.create
-    assert_equal 9, pr.errors.messages.length
+    assert_equal 11, pr.errors.messages.length
     assert_equal true, pr.invalid?
-    # assert_equal true, pr.errors.messages.keys.sort(:url)
   end
 
   def test_that_the_payload_request_is_valid
     pr = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1)
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               resolution_id: 1,
+                               user_agent_id: 1,
+                               ip_id: 1,
+                               url_id: 1, client_id: 1, key: "SHA-1")
 
     assert_equal true, pr.valid?
     assert_equal 0, pr.errors.messages.length
@@ -133,7 +129,7 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -143,7 +139,7 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 2,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     UserAgent.create(os: "Macintosh", browser: "Chrome")
     UserAgent.create(os: "Macintosh", browser: "Safari")
 
@@ -160,7 +156,7 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -170,7 +166,7 @@ class PayloadRequestTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 2,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     UserAgent.create(os: "Macintosh", browser: "Chrome")
     UserAgent.create(os: "Windows", browser: "Safari")
 
@@ -187,7 +183,7 @@ class PayloadRequestTest < Minitest::Test
                                user_agent_id: 1,
                                resolution_id: 1,
                                ip_id: 1,
-                               url_id: 1)
+                               url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                                responded_in: 20,
@@ -198,16 +194,13 @@ class PayloadRequestTest < Minitest::Test
                                user_agent_id: 1,
                                resolution_id: 1,
                                ip_id: 1,
-                               url_id: 2)
+                               url_id: 2, client_id: 1, key: "SHA-1")
 
     assert_equal 2, PayloadRequest.count
     assert_equal 100, PayloadRequest.max_response
     assert_equal 20, PayloadRequest.min_response
     assert_equal 60, PayloadRequest.average_response
   end
-
-
-# NOT WRITING TO DATABASE YET:
 
   def test_that_parsed_json_has_client_key_value_pair
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -18,15 +18,15 @@ class RequestTypeTest < Minitest::Test
 
   def test_request_type_payload_request_relationship
     pr = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1)
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               resolution_id: 1,
+                               user_agent_id: 1,
+                               ip_id: 1,
+                               url_id: 1, client_id: 1, key: "SHA-1")
     rt = RequestType.create(verb: "POST")
 
     assert_equal 1, rt.payload_requests.count
@@ -44,7 +44,7 @@ class RequestTypeTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -54,7 +54,7 @@ class RequestTypeTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -64,7 +64,7 @@ class RequestTypeTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     RequestType.create(verb: "POST")
     RequestType.create(verb: "GET")
@@ -82,7 +82,7 @@ class RequestTypeTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     RequestType.create(verb: "POST")
 

--- a/test/models/resolution_test.rb
+++ b/test/models/resolution_test.rb
@@ -19,15 +19,15 @@ class ResolutionTest < Minitest::Test
 
   def test_resolution_payload_requests_relationship
     pr = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          user_agent_id: 1,
-                          resolution_id: 1,
-                          ip_id: 1,
-                          url_id: 1)
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 1, client_id: 1, key: "SHA-1")
 
     resolution = Resolution.create(height: "1000", width: "100")
 
@@ -39,26 +39,26 @@ class ResolutionTest < Minitest::Test
 
   def test_resolution_list
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
 
     Resolution.create(height: "1", width: "1")
@@ -68,15 +68,15 @@ class ResolutionTest < Minitest::Test
     Resolution.create(height: "2", width: "2")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 2,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 2,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     assert_equal ["1 x 1", "2 x 2"], Resolution.list_of_resolutions.sort
   end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -26,7 +26,9 @@ class UrlTest < Minitest::Test
                                resolution_id: 1,
                                user_agent_id: 1,
                                ip_id: 1,
-                               url_id: 1)
+                               url_id: 1,
+                               client_id: 1,
+                               key: "SHA-1")
 
     url = Url.create(address: "www.turing.com")
 
@@ -38,55 +40,55 @@ class UrlTest < Minitest::Test
 
   def test_it_sorts_by_requested
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 2)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 2, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 3)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 3)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3, client_id: 1, key: "SHA-1")
 
     Url.create(address: "www.url1.com")
     Url.create(address: "www.url2.com")
@@ -95,25 +97,25 @@ class UrlTest < Minitest::Test
     assert_equal ["www.url1.com", "www.url3.com", "www.url2.com"], Url.most_to_least_requested
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 3)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 3)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 3, client_id: 1, key: "SHA-1")
 
     assert_equal ["www.url3.com", "www.url1.com", "www.url2.com"], Url.most_to_least_requested
   end
@@ -121,26 +123,26 @@ class UrlTest < Minitest::Test
 
   def test_response_time_list_includes_all_when_only_one_url
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     url= Url.create(address: "www.url1.com")
 
@@ -150,26 +152,26 @@ class UrlTest < Minitest::Test
 
   def test_response_time_list_includes_all_when_multiple_urls
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 2)
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 2, client_id: 1, key: "SHA-1")
 
     url= Url.create(address: "www.url1.com")
 
@@ -179,26 +181,26 @@ class UrlTest < Minitest::Test
 
   def test_response_time_list_includes_duplicates
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     url= Url.create(address: "www.url1.com")
 
@@ -208,39 +210,38 @@ class UrlTest < Minitest::Test
 
 
   def test_returns_top_referrers_for_url_less_than_3
-    #can remove skip once referrer migration happens
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 2,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 2,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 2,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 2,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 2,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 2,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 40,
+                          referrer_id: 2,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 2,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     url=Url.create(address: "www.url1.com")
 
@@ -252,50 +253,49 @@ class UrlTest < Minitest::Test
   end
 
   def test_returns_top_referrers_for_url_more_than_3
-    #can remove skip once referrer migration happens
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 48,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 1,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 2,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 2,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 40,
+                          referrer_id: 2,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 2,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 3,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 3,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 40,
+                          referrer_id: 3,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 3,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-    responded_in: 40,
-    referrer_id: 1,
-    request_type_id: 1,
-    parameters: "[]",
-    event_name_id: 4,
-    user_agent_id: 1,
-    resolution_id: 1,
-    ip_id: 1,
-    url_id: 1)
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 4,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     url = Url.create(address: "www.url1.com")
 
@@ -318,7 +318,7 @@ class UrlTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     url = Url.create(address: "www.turing.com")
     RequestType.create(verb: "GET")
@@ -336,7 +336,7 @@ class UrlTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 40,
                           referrer_id: 1,
@@ -346,7 +346,7 @@ class UrlTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     url = Url.create(address: "www.turing.com")
     RequestType.create(verb: "GET")
@@ -364,7 +364,7 @@ class UrlTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     UserAgent.create(os: "Windows", browser: "Chrome")
     url = Url.create(address: "www.turing.com")
 
@@ -382,7 +382,7 @@ class UrlTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 40,
                           referrer_id: 1,
@@ -392,47 +392,47 @@ class UrlTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 40,
-                            referrer_id: 1,
-                            request_type_id: 1,
-                            parameters: "[]",
-                            event_name_id: 4,
-                            user_agent_id: 1,
-                            resolution_id: 1,
-                            ip_id: 1,
-                            url_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 40,
-                            referrer_id: 1,
-                            request_type_id: 1,
-                            parameters: "[]",
-                            event_name_id: 4,
-                            user_agent_id: 2,
-                            resolution_id: 1,
-                            ip_id: 1,
-                            url_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 40,
-                            referrer_id: 1,
-                            request_type_id: 1,
-                            parameters: "[]",
-                            event_name_id: 4,
-                            user_agent_id: 2,
-                            resolution_id: 1,
-                            ip_id: 1,
-                            url_id: 1)
-      PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                            responded_in: 40,
-                            referrer_id: 1,
-                            request_type_id: 1,
-                            parameters: "[]",
-                            event_name_id: 4,
-                            user_agent_id: 3,
-                            resolution_id: 1,
-                            ip_id: 1,
-                            url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 4,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 4,
+                          user_agent_id: 2,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 4,
+                          user_agent_id: 2,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 40,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 4,
+                          user_agent_id: 3,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     UserAgent.create(os: "Windows", browser: "Chrome")
     UserAgent.create(os: "Macintosh", browser: "Safari")
@@ -449,36 +449,36 @@ class UrlTest < Minitest::Test
 
   def test_it_can_find_calculate_response_time_stats_for_one_url
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                               responded_in: 100,
-                               referrer_id: 1,
-                               request_type_id: 1,
-                               parameters: "[]",
-                               event_name_id: 1,
-                               user_agent_id: 1,
-                               resolution_id: 1,
-                               ip_id: 1,
-                               url_id: 1)
+                          responded_in: 100,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                               responded_in: 20,
-                               referrer_id: 1,
-                               request_type_id: 1,
-                               parameters: "[]",
-                               event_name_id: 1,
-                               user_agent_id: 1,
-                               resolution_id: 1,
-                               ip_id: 1,
-                               url_id: 1)
+                          responded_in: 20,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 1, client_id: 1, key: "SHA-1")
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                               responded_in: 2000,
-                               referrer_id: 1,
-                               request_type_id: 1,
-                               parameters: "[]",
-                               event_name_id: 1,
-                               user_agent_id: 1,
-                               resolution_id: 1,
-                               ip_id: 1,
-                               url_id: 2)
+                          responded_in: 2000,
+                          referrer_id: 1,
+                          request_type_id: 1,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          user_agent_id: 1,
+                          resolution_id: 1,
+                          ip_id: 1,
+                          url_id: 2, client_id: 1, key: "SHA-1")
 
     url = Url.create(address: "www.turing.com")
     assert_equal 100, url.max_response_for_url

--- a/test/models/user_agent_test.rb
+++ b/test/models/user_agent_test.rb
@@ -26,7 +26,7 @@ class UserAgentTest < Minitest::Test
                           user_agent_id: 1,
                           resolution_id: 1,
                           ip_id: 1,
-                          url_id: 1)
+                          url_id: 1, client_id: 1, key: "SHA-1")
 
     ua = UserAgent.create(os: "osX", browser: "Chrome")
 


### PR DESCRIPTION
Added client and key validations to payload_requests model.  Fixed tests by adding client_id and key to each PayloadRequest.create() call (closes #40 )