### PR TITLE
Dashboard controller and tests

### DIFF
--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -75,13 +75,13 @@ module RushHour
       end
     end
 
-    get '/sources/:identifier/urls/:relative_path' do |identifier, rel_path|
+    get '/sources/:identifier/urls/:rel_path' do |identifier, rel_path|
       client = Client.find_by(identifier: identifier)
       if client.relative_path_exists?(rel_path)
         @url = client.find_url_by_relative_path(rel_path)
         erb :url_dashboard
       else
-        @error_message = "The #{relative_path} URL has not yet been requested
+        @error_message = "The #{rel_path} URL has not yet been requested
                           for #{identifier.capitalize}"
         erb :error
       end

--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -5,7 +5,6 @@ module RushHour
       client = Client.new({identifier: params["identifier"],
                            root_url: params["rootUrl"]})
       name   = params[:identifier]
-
       if Client.find_by(identifier: params['identifier'])
         status 403
         body "Client with #{name.upcase} identifier is already registered."
@@ -56,25 +55,6 @@ module RushHour
       erb :error
     end
 
-    get '/sources/:identifier' do |identifier|
-      @client = Client.find_by(identifier: identifier)
-      pass unless @client
-      payload_requests = client.payload_requests
-      pass unless payload_requests
-      erb :dashboard
-    end
-
-
-    get '/sources/:identifier' do |identifier|
-      if !Client.find_by(identifier: identifier)
-        @error_message = "#{identifier.capitalize} does not exist"
-      else
-        @error_message = "There is no payload data for
-                         #{identifier.capitalize}"
-      end
-      erb :error
-    end
-
     get '/sources/:identifier/urls/:rel_path' do |identifier, rel_path|
       client = Client.find_by(identifier: identifier)
       @url = client.find_url_by_relative_path(rel_path)
@@ -82,11 +62,29 @@ module RushHour
       erb :url_dashboard
     end
 
-    get '/sources/:identifier/urls/:rel_path' do |identifier, rel_path|
-      @error_message = "The #{rel_path} URL for #{identifier.capitalize}
-                        has no request data"
+    get '/sources/:identifier/urls/*' do |identifier, splat|
+      @error_message = "No Data for #{splat} for #{identifier.capitalize}"
       erb :error
     end
-  end
 
+    get '/sources/:identifier' do |identifier|
+      @client = Client.find_by(identifier: identifier)
+      pass unless @client
+      payload_requests = @client.payload_requests
+      pass if payload_requests.empty?
+      erb :dashboard
+    end
+
+
+    get '/sources/*' do |splat|
+      if !Client.find_by(identifier: splat)
+        @error_message = "#{splat.capitalize} does not exist"
+      else
+        @error_message = "There is no payload data for:
+        #{splat.capitalize}"
+      end
+      erb :error
+    end
+
+  end
 end

--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -4,8 +4,8 @@ module RushHour
     post '/sources' do
       client = Client.new({identifier: params["identifier"],
                            root_url: params["rootUrl"]})
+      name   = params[:identifier]
 
-      name = params[:identifier]
       if Client.find_by(identifier: params['identifier'])
         status 403
         body "Client with #{name.upcase} identifier is already registered."
@@ -16,12 +16,11 @@ module RushHour
         status 400
         body "#{client.errors.full_messages.join(", ")}"
       end
-
     end
 
     post '/sources/:identifier/data' do |identifier|
       payload = params[:payload]
-      if params.empty? || !params.key?('payload') ||(payload && payload.empty?)
+      if params.empty?|| !params.key?('payload')|| (payload && payload.empty?)
         status 400
         body "Payload data was not provided."
       elsif PayloadRequest.duplicate?(params[:payload], identifier)
@@ -40,7 +39,6 @@ module RushHour
       @identifier = identifier
       @events = Client.find_by(identifier: identifier).event_names
       erb :event_index
-
     end
 
     get '/sources/:identifier/events/:event_name' do |identifier, event_name|
@@ -59,33 +57,36 @@ module RushHour
     end
 
     get '/sources/:identifier' do |identifier|
-      client = Client.find_by(identifier: identifier)
-      if Client.identifier_exists?(identifier)
-        if client.payload_requests.count > 0
-          @client = client
-          erb :dashboard
-        else
-          @error_message = "There is no payload data for
-                           #{identifier.capitalize}"
-          erb :error
-        end
-      else #no client
-        @error_message = "#{identifier.capitalize} does not yet exist"
-        erb :error
+      @client = Client.find_by(identifier: identifier)
+      pass unless @client
+      payload_requests = client.payload_requests
+      pass unless payload_requests
+      erb :dashboard
+    end
+
+
+    get '/sources/:identifier' do |identifier|
+      if !Client.find_by(identifier: identifier)
+        @error_message = "#{identifier.capitalize} does not exist"
+      else
+        @error_message = "There is no payload data for
+                         #{identifier.capitalize}"
       end
+      erb :error
     end
 
     get '/sources/:identifier/urls/:rel_path' do |identifier, rel_path|
       client = Client.find_by(identifier: identifier)
-      if client.relative_path_exists?(rel_path)
-        @url = client.find_url_by_relative_path(rel_path)
-        erb :url_dashboard
-      else
-        @error_message = "The #{rel_path} URL has not yet been requested
-                          for #{identifier.capitalize}"
-        erb :error
-      end
+      @url = client.find_url_by_relative_path(rel_path)
+      pass unless @url
+      erb :url_dashboard
     end
 
+    get '/sources/:identifier/urls/:rel_path' do |identifier, rel_path|
+      @error_message = "The #{rel_path} URL for #{identifier.capitalize}
+                        has no request data"
+      erb :error
+    end
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,10 +42,10 @@ ActiveRecord::Schema.define(version: 20160520222257) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.integer  "url_id"
-    t.integer  "referrer_id"
-    t.integer  "request_type_id"
     t.integer  "event_name_id"
+    t.integer  "request_type_id"
     t.integer  "resolution_id"
+    t.integer  "referrer_id"
     t.integer  "user_agent_id"
     t.integer  "ip_id"
     t.integer  "client_id"

--- a/test/controllers/client_can_see_events_test.rb
+++ b/test/controllers/client_can_see_events_test.rb
@@ -21,11 +21,14 @@ class SeeEventIndexTest < Minitest::Test
                                resolution_id: 1,
                                ip_id: 1,
                                url_id: 1,
-                               client_id: 1)
+                               client_id: 1,
+                               key: 1)
     get '/sources/Client1/events'
     assert_equal 200, last_response.status
-    assert_equal true, last_response.body.include?("Event Listing"
-    )
+    assert_equal true, last_response.body.include?("Event1")
+    assert_equal true, last_response.body.include?("Event1")
+    assert_equal true, last_response.body.include?("all of the events")
+
   end
 
   def test_it_hits_event_show_for_valid_event_client_combo
@@ -41,7 +44,8 @@ class SeeEventIndexTest < Minitest::Test
                                resolution_id: 1,
                                ip_id: 1,
                                url_id: 1,
-                               client_id: 1)
+                               client_id: 1,
+                               key: 1)
     get '/sources/Client1/events/Event1'
     assert_equal 200, last_response.status
     assert_equal true, last_response.body.include?("Event1")
@@ -61,10 +65,11 @@ class SeeEventIndexTest < Minitest::Test
                                resolution_id: 1,
                                ip_id: 1,
                                url_id: 1,
-                               client_id: 1)
+                               client_id: 1,
+                               key: 1)
     get '/sources/Client1/events/Event2'
     assert_equal 200, last_response.status
-    expected = "Event2 was not found."
+    expected = "Event2 was not found"
     assert_equal true, last_response.body.include?(expected)
   end
 

--- a/test/controllers/client_gets_correct_view_when_dashboard_requested.rb
+++ b/test/controllers/client_gets_correct_view_when_dashboard_requested.rb
@@ -1,0 +1,50 @@
+require_relative '../test_helper'
+
+class GetCorrectClientDashboardTest < Minitest::Test
+  include Rack::Test::Methods
+  include TestHelpers
+
+  def app
+    RushHour::Server
+  end
+
+  def test_gets_correct_route_when_client_and_payload_reqs_exist
+    Client.create(identifier: "Client2", root_url: "www.client2.com")
+    RequestType.create(verb: "GET")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 1,
+                               client_id: 1,
+                               key: 1)
+    get '/sources/Client2'
+    assert_equal 200, last_response.status
+    expected = "Welcome to the homepage of Client2"
+    assert_equal true, last_response.body.include?(expected)
+    assert_equal true, last_response.body.include?("GET")
+    assert_equal true, last_response.body.include?("48")
+
+  end
+
+  def test_gets_correct_route_when_client_exists_without_payload
+    Client.create(identifier: "Client2", root_url: "www.client2.com")
+    get '/sources/Client2'
+    assert_equal 200, last_response.status
+    expected = "There is no payload data"
+    assert_equal true, last_response.body.include?(expected)
+  end
+
+  def test_gets_correct_route_when_dashboard_request_for_invalid_client
+    get '/sources/Client3'
+    assert_equal 200, last_response.status
+    expected = "Client3 does not exist"
+    assert_equal true, last_response.body.include?(expected)
+  end
+
+end

--- a/test/controllers/url_dashboard_test.rb
+++ b/test/controllers/url_dashboard_test.rb
@@ -1,0 +1,63 @@
+require_relative '../test_helper'
+
+class GetCorrectUrlDashboardTest < Minitest::Test
+  include Rack::Test::Methods
+  include TestHelpers
+
+  def app
+    RushHour::Server
+  end
+
+  def test_gets_correct_route_when_url_reqs_exist
+    Client.create(identifier: "Client2", root_url: "www.client2.com")
+    Url.create(address: "www.client2.com/test")
+    Referrer.create(address: "www.client2.com")
+    RequestType.create(verb: "GET")
+    Resolution.create(height: "1", width: '1')
+    UserAgent.create(os: "OS", browser: "Browser")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 1,
+                               client_id: 1,
+                               key: 1)
+    get '/sources/Client2/urls/test'
+    assert_equal 200, last_response.status
+    expected = "This page provides detailed traffic analytics"
+    assert_equal true, last_response.body.include?(expected)
+    expected = "www.client2.com/test"
+    assert_equal true, last_response.body.include?(expected)
+    assert_equal true, last_response.body.include?("48")
+
+  end
+
+  def test_gets_correct_route_when_url_reqs_do_not_exist
+    Client.create(identifier: "Client2", root_url: "www.client2.com")
+    Url.create(address: "www.client2.com/test")
+    Url.create(address: "www.client2.com/test2")
+    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                               responded_in: 48,
+                               referrer_id: 1,
+                               request_type_id: 1,
+                               parameters: "[]",
+                               event_name_id: 1,
+                               user_agent_id: 1,
+                               resolution_id: 1,
+                               ip_id: 1,
+                               url_id: 1,
+                               client_id: 1,
+                               key: 1)
+    get '/sources/Client2/urls/test2'
+    assert_equal 200, last_response.status
+    expected = "No Data for test2 for Client2"
+    assert_equal true, last_response.body.include?(expected)
+  end
+
+
+end


### PR DESCRIPTION
Hey there,  This merge should:
1. fix broken route for url dashboard (relative_path was used in a few places where rel_path was needed)

2. refactor server so only one view is displayed per route (i.e. if/elses removed and else statements are treated using passes.  if you don't think this is an improvement, we can revert back.  I think it's cleaner, but i have no experience with this.  since it's fully tested now, reverting wouldn't be an issue and tests should work under either scenario.

3. controller tests for both client dashboard and url dashboard added, to include successful paths and all error events associated with both. 