### PR TITLE
created standard_payload_with_associations in test helpers, and updat…

### DIFF
--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -4,51 +4,18 @@ class ClientTest < Minitest::Test
   include TestHelpers
 
   def test_client_connections
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-    c1 = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    Client.create(identifier: "KingSoopers", root_url: "www.KingSoopers.com")
-    url = Url.create(address: "www.BestBuy.com/cameras")
-
-    assert_equal 2, c1.payload_requests.length
-    assert_equal "www.BestBuy.com/cameras", c1.urls.first.address
-    assert_equal "www.BestBuy.com", url.clients.first.root_url
+    associations = standard_payload_with_associations
+    assert_equal 1, associations[:client].payload_requests.count
+    assert_equal "www.client.com/url", associations[:client].urls.first.address
+    assert_equal "www.client.com", associations[:url].clients.first.root_url
+    #SAID WE SHOULD DO ALL
   end
 
   def test_it_calculates_average_response_time_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
+    associations = standard_payload_with_associations
+    client = associations[:client]
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 20,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
@@ -56,10 +23,9 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
+                          url_id: 1, key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 30,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
@@ -67,8 +33,8 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
+                          url_id: 1, key: "SHA-1")
+    # payload request for other client to ensure it's not using this one
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -79,17 +45,20 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2, key: "SHA-1")
+                          client_id: client.id + 1, key: "SHA-1")
 
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    assert_equal 49, client.average_response_time_for_client
+
+    assert_equal 20, client.average_response_time_for_client
 
 
   end
 
   def test_it_calculates_min_response_time_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
+
+    associations = standard_payload_with_associations
+    client = associations[:client]
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 20,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
@@ -97,10 +66,9 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
+                          url_id: 1, key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 30,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
@@ -108,8 +76,8 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
+                          url_id: 1, key: "SHA-1")
+    # payload request for other client to ensure it's not using this one
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -120,17 +88,19 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2, key: "SHA-1")
+                          client_id: client.id + 1, key: "SHA-1")
 
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    assert_equal 48, client.min_response_time_for_client
+
+    assert_equal 10, client.min_response_time_for_client
 
 
   end
 
   def test_it_calculates_max_response_time_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
+    associations = standard_payload_with_associations
+    client = associations[:client]
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 20,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
@@ -138,10 +108,9 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
+                          url_id: 1, key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 30,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
@@ -149,8 +118,8 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
+                          url_id: 1, key: "SHA-1")
+    # payload request for other client to ensure it's not using this one
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -161,84 +130,64 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: 2, key: "SHA-1")
+                          client_id: client.id + 1, key: "SHA-1")
 
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    assert_equal 50, client.max_response_time_for_client
+    assert_equal 30, client.max_response_time_for_client
 
 
   end
 
-  def test_it_calculates_max_response_time_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    req1 = RequestType.create(verb: "GET")
+  def test_it_ids_most_frequent_request_verb_for_client
+    associations = standard_payload_with_associations
+    client = associations[:client]
     req2 = RequestType.create(verb: "POST")
+
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 48,
+                          referrer_id: 1,
+                          request_type_id: req2.id,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1, key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          responded_in: 50,
+                          referrer_id: 1,
+                          request_type_id: req2.id,
+                          parameters: "[]",
+                          event_name_id: 1,
+                          resolution_id: 1,
+                          user_agent_id: 1,
+                          ip_id: 1,
+                          url_id: 1,
+                          client_id: 1, key: "SHA-1")
+
     assert_equal req2.verb, client.most_frequent_request_type_for_client
 
 
   end
 
-  def test_it_calculates_max_response_time_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+  def test_it_lists_all_request_verbs_for_client
+    associations = standard_payload_with_associations
+    client = associations[:client]
+    req2 = RequestType.create(verb: "POST")
+
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
-                          request_type_id: 1,
+                          request_type_id: req2.id,
                           parameters: "[]",
                           event_name_id: 1,
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          url_id: 1, key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
-                          request_type_id: 2,
+                          request_type_id: req2.id,
                           parameters: "[]",
                           event_name_id: 1,
                           resolution_id: 1,
@@ -246,110 +195,32 @@ class ClientTest < Minitest::Test
                           ip_id: 1,
                           url_id: 1,
                           client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    req1 = RequestType.create(verb: "GET")
-    req2 = RequestType.create(verb: "POST")
-    req3 = RequestType.create(verb: "PUT")
-    req4 = RequestType.create(verb: "DELETE")
     assert_equal ["GET", "POST"], client.all_http_verbs_for_client.sort
   end
 
   def test_it_lists_all_resoultions_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+    associations = standard_payload_with_associations
+    client = associations[:client]
+    res2 = Resolution.create(height: '2', width: '1')
+
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
                           request_type_id: 1,
                           parameters: "[]",
                           event_name_id: 1,
-                          resolution_id: 1,
+                          resolution_id: res2.id,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 2,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 4,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    Resolution.create(height: '1', width: '1')
-    Resolution.create(height: '2', width: '1')
-    Resolution.create(height: '3', width: '1')
-    Resolution.create(height: '4', width: '1')
-
+                          url_id: 1, key: "SHA-1")
     assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 1")
     assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 2")
-    assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 3")
-    assert_equal false, client.all_screen_resolutions_for_client.include?("1 x 4")
-    assert_equal ["1 x 1", "1 x 2", "1 x 3"], client.all_screen_resolutions_for_client.uniq.sort
+    assert_equal ["1 x 1", "1 x 2"], client.all_screen_resolutions_for_client.uniq.sort
 
   end
 
   def test_it_provides_breakdown_of_all_browswers_for_client
+    #LEFT OFF HERE
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
@@ -730,16 +601,16 @@ class ClientTest < Minitest::Test
                           client_id: 1, key: "SHA-1")
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     event = EventName.create(name: "event1")
-  
+
     expected = {21.0 =>2, 20.0 =>1}
     assert_equal expected, client.event_requests_by_hour("event1")
   end
 
   def test_groups_events_by_hour_returns_empty_if_no_requests
-  
+
     client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
     event = EventName.create(name: "event1")
-  
+
     assert_equal ({}), client.event_requests_by_hour("event1")
   end
 end

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -3,38 +3,36 @@ require_relative "../test_helper"
 class ClientTest < Minitest::Test
   include TestHelpers
 
-  def test_client_connections
-    associations = standard_payload_with_associations
-    assert_equal 1, associations[:client].payload_requests.count
-    assert_equal "www.client.com/url", associations[:client].urls.first.address
-    assert_equal "www.client.com", associations[:url].clients.first.root_url
-    #SAID WE SHOULD DO ALL
+  def test_client_connections_to_other_tables
+    aggregate_setup
+
+    assert_equal 12, client.payload_requests.count
+    assert_equal "www.least.com", client.urls.first.address
+    assert_equal "www.@referrer1.com", client.referrers.first.address
+    assert_equal "GET", client.request_types.first.verb
+    assert_equal "event_most", client.event_names.first.name
+    assert_equal "OSX", client.user_agents.first.os
+    assert_equal "1920", client.resolutions.first.width
+    assert_equal "100.00.00.00", client.ips.first.address
+
   end
 
-  def test_it_calculates_average_response_time_for_client
-    associations = standard_payload_with_associations
-    client = associations[:client]
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 20,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 30,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    # payload request for other client to ensure it's not using this one
+  def test_other_table_connections_to_client
+    aggregate_setup
+
+    expected = "http://jumpstartlab.com"
+
+    assert_equal expected, @url_least.clients.first.root_url
+    assert_equal expected, @referrer1.clients.first.root_url
+    assert_equal expected, @request_type_most.clients.first.root_url
+    assert_equal expected, @event_name_most.clients.first.root_url
+    assert_equal expected, @user_agent1.clients.first.root_url
+    assert_equal expected, @resolution_most.clients.first.root_url
+
+  end
+
+  def test_it_excludes_data_for_other_client
+    aggregate_setup
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -45,312 +43,67 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: client.id + 1, key: "SHA-1")
+                          client_id: @client.id + 1,
+                          key: "SHA-1")
+
+    assert_equal 12, client.payload_requests.count
+  end
 
 
-    assert_equal 20, client.average_response_time_for_client
+  def test_it_calculates_average_response_time_for_client
+    aggregate_setup
 
+    assert_equal @avg_response_time, @client.average_response_time_for_client.to_f.round(2)
 
   end
 
   def test_it_calculates_min_response_time_for_client
+    aggregate_setup
 
-    associations = standard_payload_with_associations
-    client = associations[:client]
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 20,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 30,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    # payload request for other client to ensure it's not using this one
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: client.id + 1, key: "SHA-1")
-
-
-    assert_equal 10, client.min_response_time_for_client
-
-
+    assert_equal @min_response_time, client.min_response_time_for_client
   end
 
   def test_it_calculates_max_response_time_for_client
-    associations = standard_payload_with_associations
-    client = associations[:client]
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 20,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 30,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    # payload request for other client to ensure it's not using this one
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: client.id + 1, key: "SHA-1")
+    aggregate_setup
 
-    assert_equal 30, client.max_response_time_for_client
-
+    assert_equal @max_response_time, client.max_response_time_for_client
 
   end
 
   def test_it_ids_most_frequent_request_verb_for_client
-    associations = standard_payload_with_associations
-    client = associations[:client]
-    req2 = RequestType.create(verb: "POST")
+    aggregate_setup
 
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: req2.id,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: req2.id,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-
-    assert_equal req2.verb, client.most_frequent_request_type_for_client
-
+    assert_equal @request_type_most.verb, client.most_frequent_request_type_for_client
 
   end
 
   def test_it_lists_all_request_verbs_for_client
-    associations = standard_payload_with_associations
-    client = associations[:client]
-    req2 = RequestType.create(verb: "POST")
+    aggregate_setup
 
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: req2.id,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: req2.id,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    assert_equal ["GET", "POST"], client.all_http_verbs_for_client.sort
+    assert_equal ["GET", "PATCH", "POST"], client.all_http_verbs_for_client.sort
   end
 
   def test_it_lists_all_resoultions_for_client
-    associations = standard_payload_with_associations
-    client = associations[:client]
-    res2 = Resolution.create(height: '2', width: '1')
+    aggregate_setup
 
-    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: res2.id,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1, key: "SHA-1")
-    assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 1")
-    assert_equal true, client.all_screen_resolutions_for_client.include?("1 x 2")
-    assert_equal ["1 x 1", "1 x 2"], client.all_screen_resolutions_for_client.uniq.sort
+    assert_equal 2, client.all_screen_resolutions_for_client.count
+
+    expected = "#{@resolution_most.width}" + " x " + "#{@resolution_most.height}"
+    assert_equal true, client.all_screen_resolutions_for_client.include?(expected)
 
   end
 
   def test_it_provides_breakdown_of_all_browswers_for_client
-    #LEFT OFF HERE
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 2,
-                          user_agent_id: 2,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 4,
-                          user_agent_id: 3,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    UserAgent.create(browser: 'IE', os: 'Windows')
-    UserAgent.create(browser: 'Chrome', os: 'Windows')
-    UserAgent.create(browser: 'Firefox', os: 'Windows')
-
-    expected = {"IE" => 3, "Chrome" => 1}
+    aggregate_setup
+    expected = {"Chrome"=>8, "IE"=>2, "Safari"=>2}
     assert_equal expected, client.browser_breakdown_for_client
   end
 
 
   def test_it_provides_breakdown_of_all_operating_systems_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 2,
-                          user_agent_id: 2,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
+    aggregate_setup
 
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 4,
-                          user_agent_id: 3,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    UserAgent.create(browser: 'IE', os: 'Windows')
-    UserAgent.create(browser: 'Chrome', os: 'OSX')
-    UserAgent.create(browser: 'Firefox', os: 'Linux')
-    expected = {"Windows" => 3, "OSX" => 1}
+    expected = {"OSX"=>6, "Windows"=>4, "Linux"=>2}
 
     assert_equal expected, client.operating_system_breakdown_for_client
 
@@ -358,74 +111,17 @@ class ClientTest < Minitest::Test
 
 
   def test_it_lists_all_urls_by_requests_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 2,
-                          user_agent_id: 2,
-                          ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 4,
-                          user_agent_id: 3,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    Url.create(address: "www.test.com")
-    Url.create(address: "www.test.com/list")
-    Url.create(address: "www.test.com/new")
-    expected = ["www.test.com/new", "www.test.com"]
+    aggregate_setup
+    expected = ["www.most.com", "www.least.com"]
 
     assert_equal expected, client.url_list_ordered_by_request_count
   end
 
   def test_client_can_return_list_of_relative_paths
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+
+    client = Client.create(identifier: "BestBuy", root_url: "www.test.com")
+    url = Url.create(address: "www.BestBuy.com/list")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
                           request_type_id: 1,
@@ -434,66 +130,21 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 2,
-                          user_agent_id: 2,
-                          ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 2,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 4,
-                          user_agent_id: 3,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.test.com")
-    Url.create(address: "www.test.com")
-    Url.create(address: "www.test.com/list")
-    Url.create(address: "www.test.com/new")
+                          url_id: url.id,
+                          key: "SHA-1")
 
     result = client.find_url_by_relative_path("list")
 
-    assert_equal "www.test.com/list", result.address
+    assert_equal "www.BestBuy.com/list", result.address
   end
 
   def test_relative_path_exists
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+
+    client = Client.create(identifier: "BestBuy", root_url: "www.test.com")
+    url1 = Url.create(address: "www.test.com")
+    url2 = Url.create(address: "www.test.com/list")
+    url3 = Url.create(address: "www.test.com/new")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 48,
                           referrer_id: 1,
                           request_type_id: 1,
@@ -502,9 +153,9 @@ class ClientTest < Minitest::Test
                           resolution_id: 1,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          url_id: url1.id,
+                          key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
                           request_type_id: 2,
@@ -513,9 +164,9 @@ class ClientTest < Minitest::Test
                           resolution_id: 2,
                           user_agent_id: 2,
                           ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                          url_id: url2.id,
+                          key: "SHA-1")
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 50,
                           referrer_id: 1,
                           request_type_id: 2,
@@ -524,93 +175,18 @@ class ClientTest < Minitest::Test
                           resolution_id: 3,
                           user_agent_id: 1,
                           ip_id: 1,
-                          url_id: 3,
-                          client_id: 1, key: "SHA-1")
-
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 50,
-                          referrer_id: 1,
-                          request_type_id: 2,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 3,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 2,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 100,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 4,
-                          user_agent_id: 3,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 2, key: "SHA-1")
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.test.com")
-    Url.create(address: "www.test.com")
-    Url.create(address: "www.test.com/list")
-    Url.create(address: "www.test.com/new")
+                          url_id: url3.id,
+                          key: "SHA-1")
 
     assert client.relative_path_exists?("list")
     assert client.relative_path_exists?("new")
     refute client.relative_path_exists?("gokart")
   end
 
-
-
-
-
-
   def test_it_groups_events_by_hour_for_client
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    PayloadRequest.create(requested_at: "2013-02-16 20:38:28 -0700",
-                          responded_in: 48,
-                          referrer_id: 1,
-                          request_type_id: 1,
-                          parameters: "[]",
-                          event_name_id: 1,
-                          resolution_id: 1,
-                          user_agent_id: 1,
-                          ip_id: 1,
-                          url_id: 1,
-                          client_id: 1, key: "SHA-1")
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    event = EventName.create(name: "event1")
-
-    expected = {21.0 =>2, 20.0 =>1}
-    assert_equal expected, client.event_requests_by_hour("event1")
+    aggregate_setup
+    expected = {21.0=>8, 20.0=>1}
+    assert_equal expected, client.event_requests_by_hour(@event_name_most.name)
   end
 
-  def test_groups_events_by_hour_returns_empty_if_no_requests
-
-    client = Client.create(identifier: "BestBuy", root_url: "www.BestBuy.com")
-    event = EventName.create(name: "event1")
-
-    assert_equal ({}), client.event_requests_by_hour("event1")
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,7 @@ Capybara.app = RushHour::Server
 DatabaseCleaner.strategy = :truncation
 
 module TestHelpers
+  attr_reader :client
   def setup
     DatabaseCleaner.start
     super
@@ -26,27 +27,220 @@ module TestHelpers
     super
   end
 
-  def standard_payload_with_associations
-    client = Client.create(identifier: "Client", root_url: "www.client.com")
-    event = EventName.create(name: "Event")
-    referrer = Referrer.create(address: "www.referrer.com")
-    request_type = RequestType.create(verb: "GET")
-    resolution = Resolution.create(width: 1, height: 1)
-    url = Url.create(address: "www.client.com/url")
-    user_agent = UserAgent.create(os: "OS", browser: "Browser")
-    payload_request = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
-                      responded_in: 10,
-                      parameters: "[]",
-                      url_id: url.id,
-                      event_name_id: event.id,
-                      request_type_id: request_type.id,
-                      resolution_id: resolution.id,
-                      referrer_id: referrer.id,
-                      user_agent_id: user_agent.id,
-                      ip_id: 1,
-                      client_id: client.id,
-                      key: "SHA")
-    {client: client, event: event, referrer: referrer, request_type: request_type, resolution: resolution, url: url, user_agent: user_agent, payload_request: payload_request}
+  # def standard_payload_with_associations
+  #   client = Client.create(identifier: "Client", root_url: "www.client.com")
+  #   event = EventName.create(name: "Event")
+  #   referrer = Referrer.create(address: "www.referrer.com")
+  #   request_type = RequestType.create(verb: "GET")
+  #   resolution = Resolution.create(width: 1, height: 1)
+  #   url = Url.create(address: "www.client.com/url")
+  #   user_agent = UserAgent.create(os: "OS", browser: "Browser")
+  #   payload_request = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+  #   responded_in: 10,
+  #   parameters: "[]",
+  #   url_id: url.id,
+  #   event_name_id: event.id,
+  #   request_type_id: request_type.id,
+  #   resolution_id: resolution.id,
+  #   referrer_id: referrer.id,
+  #   user_agent_id: user_agent.id,
+  #   ip_id: 1,
+  #   client_id: client.id,
+  #   key: "SHA")
+  #   {client: client, event: event, referrer: referrer, request_type: request_type, resolution: resolution, url: url, user_agent: user_agent, payload_request: payload_request}
+  # end
+
+  def aggregate_setup
+    @client = Client.create(identifier: "jumpstartlab", root_url: "http://jumpstartlab.com")
+
+    @url_least = Url.find_or_create_by({address: "www.least.com"})
+    @url_most = Url.find_or_create_by({address: "www.most.com"})
+
+    @referrer1 = Referrer.find_or_create_by({address: "www.@referrer1.com"})
+    referrer2 = Referrer.find_or_create_by({address: "www.referrer2.com"})
+
+    @request_type_most = RequestType.find_or_create_by({verb: "GET"})
+    request_type_post = RequestType.find_or_create_by({verb: "POST"})
+    request_type_patch = RequestType.find_or_create_by({verb: "PATCH"})
+
+    @event_name_most  = EventName.find_or_create_by({name: "event_most"})
+    @event_name_least = EventName.find_or_create_by({name: "event_least"})
+
+    @user_agent1 = UserAgent.find_or_create_by({os: "OSX", browser: "Chrome"})
+    user_agent2 = UserAgent.find_or_create_by({os: "OSX", browser: "Safari"})
+    user_agent3 = UserAgent.find_or_create_by({os: "Windows", browser: "Chrome"})
+    user_agent4 = UserAgent.find_or_create_by({os: "Linux", browser: "Chrome"})
+    user_agent5 = UserAgent.find_or_create_by({os: "Windows", browser: "IE"})
+
+    @resolution_most = Resolution.find_or_create_by({width: "1920", height: "1080"})
+    @resolution_least = Resolution.find_or_create_by({width: "1600", height: "1200"})
+
+    ip = Ip.find_or_create_by(address: "100.00.00.00")
+
+    response_time1 = 30
+    response_time2 = 45
+    response_time3 = 40
+    response_time4 = 55
+
+    @avg_response_time = ((response_time1 + response_time2 + response_time3 + response_time4) / 4.0).round(2)
+    @max_response_time = response_time4
+    @min_response_time = response_time1
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 20:38:28 -0700",
+    responded_in: response_time1,
+    referrer: @referrer1,
+    request_type: @request_type_most,
+    parameters: "[]",
+    event_name: @event_name_least,
+    user_agent: @user_agent1,
+    resolution: @resolution_most,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_least ,
+    requested_at: "2013-02-16 20:38:28 -0700",
+    responded_in: response_time2,
+    referrer: referrer2,
+    request_type: @request_type_most,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: user_agent2,
+    resolution: @resolution_most,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time3,
+    referrer: @referrer1,
+    request_type: @request_type_most,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: user_agent3,
+    resolution: @resolution_least,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time4,
+    referrer: referrer2,
+    request_type: request_type_patch,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: user_agent4,
+    resolution: @resolution_least,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time1,
+    referrer: @referrer1,
+    request_type: request_type_post,
+    parameters: "[]",
+    event_name: @event_name_least,
+    user_agent: user_agent5,
+    resolution: @resolution_most,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_least ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time2,
+    referrer: referrer2,
+    request_type: request_type_post,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: @user_agent1,
+    resolution: @resolution_most,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time3,
+    referrer: @referrer1,
+    request_type: @request_type_most,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: user_agent2,
+    resolution: @resolution_least,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time4,
+    referrer: referrer2,
+    request_type: request_type_patch,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: user_agent3,
+    resolution: @resolution_least,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time1,
+    referrer: @referrer1,
+    request_type: request_type_post,
+    parameters: "[]",
+    event_name: @event_name_least,
+    user_agent: user_agent4,
+    resolution: @resolution_most,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time2,
+    referrer: referrer2,
+    request_type: @request_type_most,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: user_agent5,
+    resolution: @resolution_least,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time3,
+    referrer: @referrer1,
+    request_type: @request_type_most,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: @user_agent1,
+    resolution: @resolution_most,
+    client: client,
+    ip: ip,
+    key: "SHA1")
+
+    PayloadRequest.create(url: @url_most ,
+    requested_at: "2013-02-16 21:38:28 -0700",
+    responded_in: response_time4,
+    referrer: referrer2,
+    request_type: request_type_patch,
+    parameters: "[]",
+    event_name: @event_name_most,
+    user_agent: @user_agent1,
+    resolution: @resolution_least,
+    client: client,
+    ip: ip,
+    key: "SHA1")
   end
 
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,30 @@ module TestHelpers
     DatabaseCleaner.clean
     super
   end
+
+  def standard_payload_with_associations
+    client = Client.create(identifier: "Client", root_url: "www.client.com")
+    event = EventName.create(name: "Event")
+    referrer = Referrer.create(address: "www.referrer.com")
+    request_type = RequestType.create(verb: "GET")
+    resolution = Resolution.create(width: 1, height: 1)
+    url = Url.create(address: "www.client.com/url")
+    user_agent = UserAgent.create(os: "OS", browser: "Browser")
+    payload_request = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 10,
+                      parameters: "[]",
+                      url_id: url.id,
+                      event_name_id: event.id,
+                      request_type_id: request_type.id,
+                      resolution_id: resolution.id,
+                      referrer_id: referrer.id,
+                      user_agent_id: user_agent.id,
+                      ip_id: 1,
+                      client_id: client.id,
+                      key: "SHA")
+    {client: client, event: event, referrer: referrer, request_type: request_type, resolution: resolution, url: url, user_agent: user_agent, payload_request: payload_request}
+  end
+
 end
 
 Capybara.app = RushHour::Server


### PR DESCRIPTION
So this one has NOTHING to do with readme... forgot to make a new branch.  This is really about NOT HARDCODING our tests :)

Since the previous version below still required us to add a lot of payload request on top of the standard payload, and then customize those additional pr's based on what we were testing -- I went another route.  Now we have an `aggregate_setup` method in testhelpers.

`aggregate_setup` includes 12 payload requests, all tied to a single client.  There are multiple request_types, event_names, etc, etc., so we can test the various methods that rely on counting, ordering. etc, all using this standard setup.  Additionally, many are assigned to instance variables so we can call them directly in the tests.    

For example, something like this is now possible: 

```
  def test_it_ids_most_frequent_request_verb_for_client
    aggregate_setup
    assert_equal @request_type_most.verb, client.most_frequent_request_type_for_client
  end
```

I fully updated the client model test - which I think was the worst offender by far with hardcoding.  Can someone take on the rest of the model tests.  Also, there is one test erroring out in Client Model test that I don't really have the stamina to fix, and I don't fully understand the relative path method. Can someone fix.



I left the previous version below in case anyone prefers this alternative.  
***** Previous Version **********
Not sure this is the best solution, but here's what I have:

* new method in test helpers that creates one payload with truly associated instances of all other things.  it returns a hash of all those things so you can access them if you need them.


```
def standard_payload_with_associations
    client = Client.create(identifier: "Client", root_url: "www.client.com")
    event = EventName.create(name: "Event")
    referrer = Referrer.create(address: "www.referrer.com")
    request_type = RequestType.create(verb: "GET")
    resolution = Resolution.create(width: 1, height: 1)
    url = Url.create(address: "www.client.com/url")
    user_agent = UserAgent.create(os: "OS", browser: "Browser")
    payload_request = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                      responded_in: 10,
                      parameters: "[]",
                      url_id: url.id,
                      event_name_id: event.id,
                      request_type_id: request_type.id,
                      resolution_id: resolution.id,
                      referrer_id: referrer.id,
                      user_agent_id: user_agent.id,
                      ip_id: 1,
                      client_id: client.id,
                      key: "SHA")
    {client: client, event: event, referrer: referrer, request_type: request_type, resolution: resolution, url: url, user_agent: user_agent, payload_request: payload_request}
  end
```


*  then you can do something like this in your tests:


```
  def test_client_connections
    associations = standard_payload_with_associations
    assert_equal 1, associations[:client].payload_requests.count
    assert_equal "www.client.com/url", associations[:client].urls.first.address
    assert_equal "www.client.com", associations[:url].clients.first.root_url
  end
```

* of course there are tests where you  need multiple PRs, so you would need this PLUS some other PRs.  But we should associate those PRs with our client.  That would look something like this (notice no client_id gets passed in):



```
  def test_it_calculates_average_response_time_for_client
    associations = standard_payload_with_associations
    client = associations[:client]
    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                          responded_in: 20,
                          referrer_id: 1,
                          request_type_id: 1,
                          parameters: "[]",
                          event_name_id: 1,
                          resolution_id: 1,
                          user_agent_id: 1,
                          ip_id: 1,
                          url_id: 1, key: "SHA-1")
```

I got through updating client_model test like this through about line 200ish.  I put a comment in to show where I left off.

I'm not sure this is the best solution, so please feel free to change it up.  

