### PR TITLE
Redo tests

### DIFF
--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -4,35 +4,35 @@ class ClientTest < Minitest::Test
   include TestHelpers
 
   def test_client_connections_to_other_tables
-    aggregate_setup
+    standard_payload_with_associations
 
-    assert_equal 12, client.payload_requests.count
-    assert_equal "www.least.com", client.urls.first.address
-    assert_equal "www.@referrer1.com", client.referrers.first.address
-    assert_equal "GET", client.request_types.first.verb
-    assert_equal "event_most", client.event_names.first.name
-    assert_equal "OSX", client.user_agents.first.os
-    assert_equal "1920", client.resolutions.first.width
-    assert_equal "127.0.0.1", client.ips.first.address
+    assert_equal 1, @client.payload_requests.count
+    assert_equal "www.client.com/most", @client.urls.first.address
+    assert_equal "www.MostReferrer.com", @client.referrers.first.address
+    assert_equal "MOST", @client.request_types.first.verb
+    assert_equal "MostEvent", @client.event_names.first.name
+    assert_equal "MostOS", @client.user_agents.first.os
+    assert_equal "1", @client.resolutions.first.width
+    assert_equal "ip", @client.ips.first.address
 
   end
 
   def test_other_table_connections_to_client
-    aggregate_setup
+    associations = standard_payload_with_associations
 
-    expected = "http://jumpstartlab.com"
+    expected = "www.client.com"
 
-    assert_equal expected, @url_least.clients.first.root_url
-    assert_equal expected, @referrer1.clients.first.root_url
-    assert_equal expected, @request_type_most.clients.first.root_url
-    assert_equal expected, @event_name_most.clients.first.root_url
-    assert_equal expected, @user_agent1.clients.first.root_url
-    assert_equal expected, @resolution_most.clients.first.root_url
+    assert_equal expected, associations[:url].clients.first.root_url
+    assert_equal expected, associations[:referrer].clients.first.root_url
+    assert_equal expected, associations[:request_type].clients.first.root_url
+    assert_equal expected, associations[:event].clients.first.root_url
+    assert_equal expected, associations[:user_agent].clients.first.root_url
+    assert_equal expected, associations[:resolution].clients.first.root_url
 
   end
 
   def test_it_excludes_data_for_other_client
-    aggregate_setup
+    standard_payload_with_associations
     PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
                           responded_in: 100,
                           referrer_id: 1,
@@ -46,92 +46,216 @@ class ClientTest < Minitest::Test
                           client_id: @client.id + 1,
                           key: "SHA-1")
 
-    assert_equal 12, client.payload_requests.count
+    assert_equal 1, @client.payload_requests.count
   end
 
 
   def test_it_calculates_average_response_time_for_client
-    aggregate_setup
+    standard_payload_with_associations
 
-    assert_equal @avg_response_time, @client.average_response_time_for_client.to_f.round(2)
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
+
+    assert_equal 15, @client.average_response_time_for_client
 
   end
 
   def test_it_calculates_min_response_time_for_client
-    aggregate_setup
-
-    assert_equal @min_response_time, client.min_response_time_for_client
+    standard_payload_with_associations
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
+    assert_equal 10, @client.min_response_time_for_client
   end
 
   def test_it_calculates_max_response_time_for_client
-    aggregate_setup
+    standard_payload_with_associations
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
 
-    assert_equal @max_response_time, client.max_response_time_for_client
+    assert_equal 20, @client.max_response_time_for_client
 
   end
 
   def test_it_ids_most_frequent_request_verb_for_client
-    aggregate_setup
+    associations = standard_payload_with_associations
+    request_type_least = RequestType.create(verb: "LEAST")
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: associations[:request_type].id,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type: request_type_least,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
 
-    assert_equal @request_type_most.verb, client.most_frequent_request_type_for_client
+    assert_equal "MOST", @client.most_frequent_request_type_for_client
 
   end
 
   def test_it_lists_all_request_verbs_for_client
-    aggregate_setup
+    standard_payload_with_associations
+    request_type_least = RequestType.create(verb: "LEAST")
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type: request_type_least,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
 
-    assert_equal ["GET", "PATCH", "POST"], client.all_http_verbs_for_client.sort
+    assert_equal ["LEAST", "MOST"], client.all_http_verbs_for_client.sort
   end
 
-  def test_it_lists_all_resoultions_for_client
-    aggregate_setup
+  def test_it_lists_all_resolutions_for_client
+    standard_payload_with_associations
+    resolution = Resolution.create(width: 2, height: 2)
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution: resolution,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
 
-    assert_equal 2, client.all_screen_resolutions_for_client.count
-
-    expected = "#{@resolution_most.width}" + " x " + "#{@resolution_most.height}"
-    assert_equal true, client.all_screen_resolutions_for_client.include?(expected)
+    expected = ["1 x 1", "2 x 2"]
+    assert_equal expected, client.all_screen_resolutions_for_client.sort
 
   end
 
   def test_it_provides_breakdown_of_all_browswers_for_client
-    aggregate_setup
-    expected = {"Chrome"=>8, "IE"=>2, "Safari"=>2}
+    standard_payload_with_associations
+    user_agent = UserAgent.create(os: "OtherOS", browser: "OtherBrowser")
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent: user_agent,
+                      ip_id: 1,
+                      key: "SHA2")
+
+    expected = {"MostBrowser"=>1, "OtherBrowser"=>1}
     assert_equal expected, client.browser_breakdown_for_client
   end
 
 
   def test_it_provides_breakdown_of_all_operating_systems_for_client
-    aggregate_setup
+    standard_payload_with_associations
+    user_agent = UserAgent.create(os: "OtherOS", browser: "OtherBrowser")
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent: user_agent,
+                      ip_id: 1,
+                      key: "SHA2")
 
-    expected = {"OSX"=>6, "Windows"=>4, "Linux"=>2}
-
+    expected = {"MostOS"=>1, "OtherOS"=>1}
     assert_equal expected, client.operating_system_breakdown_for_client
 
   end
 
 
   def test_it_lists_all_urls_by_requests_for_client
-    aggregate_setup
-    expected = ["www.most.com", "www.least.com"]
+    associations = standard_payload_with_associations
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url: associations[:url],
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
 
+    url = Url.create(address: 'www.client.com/least')
+    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url: url,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA3")
+
+
+    expected = ["www.client.com/most", "www.client.com/least"]
     assert_equal expected, client.url_list_ordered_by_request_count
   end
 
   def test_client_can_return_list_of_relative_paths
-    relative_url_setup
-
-    expected = "www.relative.com/path"
-
-    assert_equal expected, client.find_url_by_relative_path("path").address
+    associations = standard_payload_with_associations
+    expected = "www.client.com/most"
+    assert_equal expected, client.find_url_by_relative_path("most").address
   end
 
   def test_relative_path_exists
-    relative_url_setup
+    associations = standard_payload_with_associations
 
-    assert client.relative_path_exists?("path")
-    assert client.relative_path_exists?("list")
-    assert client.relative_path_exists?("new")
-    refute client.relative_path_exists?("bad_path")
+    assert client.relative_path_exists?("most")
+    refute client.relative_path_exists?("other")
+
   end
 
   def test_it_groups_events_by_hour_for_client

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -6,14 +6,14 @@ class ClientTest < Minitest::Test
   def test_client_connections_to_other_tables
     standard_payload_with_associations
 
-    assert_equal 1, @client.payload_requests.count
-    assert_equal "www.client.com/most", @client.urls.first.address
-    assert_equal "www.MostReferrer.com", @client.referrers.first.address
-    assert_equal "MOST", @client.request_types.first.verb
-    assert_equal "MostEvent", @client.event_names.first.name
-    assert_equal "MostOS", @client.user_agents.first.os
-    assert_equal "1", @client.resolutions.first.width
-    assert_equal "ip", @client.ips.first.address
+    assert_equal 1, client.payload_requests.count
+    assert_equal "www.client.com/most", client.urls.first.address
+    assert_equal "www.MostReferrer.com", client.referrers.first.address
+    assert_equal "MOST", client.request_types.first.verb
+    assert_equal "MostEvent", client.event_names.first.name
+    assert_equal "MostOS", client.user_agents.first.os
+    assert_equal "1", client.resolutions.first.width
+    assert_equal "ip", client.ips.first.address
 
   end
 
@@ -21,7 +21,6 @@ class ClientTest < Minitest::Test
     associations = standard_payload_with_associations
 
     expected = "www.client.com"
-
     assert_equal expected, associations[:url].clients.first.root_url
     assert_equal expected, associations[:referrer].clients.first.root_url
     assert_equal expected, associations[:request_type].clients.first.root_url
@@ -43,10 +42,11 @@ class ClientTest < Minitest::Test
                           user_agent_id: 1,
                           ip_id: 1,
                           url_id: 1,
-                          client_id: @client.id + 1,
+                          client_id: client.id + 1,
                           key: "SHA-1")
 
-    assert_equal 1, @client.payload_requests.count
+    assert_equal 1, client.payload_requests.count
+
   end
 
 
@@ -65,7 +65,7 @@ class ClientTest < Minitest::Test
                       ip_id: 1,
                       key: "SHA2")
 
-    assert_equal 15, @client.average_response_time_for_client
+    assert_equal 15, client.average_response_time_for_client
 
   end
 
@@ -82,7 +82,9 @@ class ClientTest < Minitest::Test
                       user_agent_id: 1,
                       ip_id: 1,
                       key: "SHA2")
-    assert_equal 10, @client.min_response_time_for_client
+
+    assert_equal 10, client.min_response_time_for_client
+
   end
 
   def test_it_calculates_max_response_time_for_client
@@ -99,25 +101,25 @@ class ClientTest < Minitest::Test
                       ip_id: 1,
                       key: "SHA2")
 
-    assert_equal 20, @client.max_response_time_for_client
+    assert_equal 20, client.max_response_time_for_client
 
   end
 
   def test_it_ids_most_frequent_request_verb_for_client
     associations = standard_payload_with_associations
     request_type_least = RequestType.create(verb: "LEAST")
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url_id: 1,
                       event_name_id: 1,
-                      request_type_id: associations[:request_type].id,
+                      request_type: associations[:request_type],
                       resolution_id: 1,
                       referrer_id: 1,
                       user_agent_id: 1,
                       ip_id: 1,
                       key: "SHA2")
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url_id: 1,
@@ -129,14 +131,14 @@ class ClientTest < Minitest::Test
                       ip_id: 1,
                       key: "SHA2")
 
-    assert_equal "MOST", @client.most_frequent_request_type_for_client
+    assert_equal "MOST", client.most_frequent_request_type_for_client
 
   end
 
   def test_it_lists_all_request_verbs_for_client
     standard_payload_with_associations
     request_type_least = RequestType.create(verb: "LEAST")
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url_id: 1,
@@ -149,12 +151,13 @@ class ClientTest < Minitest::Test
                       key: "SHA2")
 
     assert_equal ["LEAST", "MOST"], client.all_http_verbs_for_client.sort
+
   end
 
   def test_it_lists_all_resolutions_for_client
     standard_payload_with_associations
     resolution = Resolution.create(width: 2, height: 2)
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url_id: 1,
@@ -174,7 +177,7 @@ class ClientTest < Minitest::Test
   def test_it_provides_breakdown_of_all_browswers_for_client
     standard_payload_with_associations
     user_agent = UserAgent.create(os: "OtherOS", browser: "OtherBrowser")
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url_id: 1,
@@ -188,13 +191,14 @@ class ClientTest < Minitest::Test
 
     expected = {"MostBrowser"=>1, "OtherBrowser"=>1}
     assert_equal expected, client.browser_breakdown_for_client
+
   end
 
 
   def test_it_provides_breakdown_of_all_operating_systems_for_client
     standard_payload_with_associations
     user_agent = UserAgent.create(os: "OtherOS", browser: "OtherBrowser")
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url_id: 1,
@@ -214,7 +218,7 @@ class ClientTest < Minitest::Test
 
   def test_it_lists_all_urls_by_requests_for_client
     associations = standard_payload_with_associations
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url: associations[:url],
@@ -227,7 +231,7 @@ class ClientTest < Minitest::Test
                       key: "SHA2")
 
     url = Url.create(address: 'www.client.com/least')
-    @client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
+    client.payload_requests.create(requested_at: "2013-02-16 21:38:28 -0700",
                       responded_in: 20,
                       parameters: "[]",
                       url: url,
@@ -242,16 +246,18 @@ class ClientTest < Minitest::Test
 
     expected = ["www.client.com/most", "www.client.com/least"]
     assert_equal expected, client.url_list_ordered_by_request_count
+
   end
 
   def test_client_can_return_list_of_relative_paths
-    associations = standard_payload_with_associations
+    standard_payload_with_associations
+
     expected = "www.client.com/most"
     assert_equal expected, client.find_url_by_relative_path("most").address
   end
 
   def test_relative_path_exists
-    associations = standard_payload_with_associations
+    standard_payload_with_associations
 
     assert client.relative_path_exists?("most")
     refute client.relative_path_exists?("other")
@@ -259,9 +265,21 @@ class ClientTest < Minitest::Test
   end
 
   def test_it_groups_events_by_hour_for_client
-    aggregate_setup
-    expected = {21.0=>8, 20.0=>1}
-    assert_equal expected, client.event_requests_by_hour(@event_name_most.name)
+    associations = standard_payload_with_associations
+    client.payload_requests.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name: associations[:event],
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      key: "SHA2")
+                      
+    expected = {21.0=>1, 1.0=>1}
+    assert_equal expected, client.event_requests_by_hour(associations[:event].name)
   end
 
 end

--- a/test/models/event_name_test.rb
+++ b/test/models/event_name_test.rb
@@ -16,10 +16,17 @@ class EventNameTest < Minitest::Test
     assert_equal 1, event_name.errors.messages.length
   end
 
+  def test_event_payload_connection
+    event_name = EventName.create
+
+    assert event_name.respond_to?(:payload_requests)
+  end
+
   def test_event_name_payload_requests_relationship
     associations = standard_payload_with_associations
 
     assert_equal 1, associations[:event].payload_requests.count
+
   end
 
   def test_it_sorts_by_requested

--- a/test/models/event_name_test.rb
+++ b/test/models/event_name_test.rb
@@ -17,18 +17,41 @@ class EventNameTest < Minitest::Test
   end
 
   def test_event_name_payload_requests_relationship
-    aggregate_setup
+    associations = standard_payload_with_associations
 
-    assert_equal 9, @event_name_most.payload_requests.count
-    assert_equal 3, @event_name_least.payload_requests.count
-
-    assert_equal "event_least", PayloadRequest.first.event_name.name
+    assert_equal 1, associations[:event].payload_requests.count
   end
 
   def test_it_sorts_by_requested
-    aggregate_setup
+    associations = standard_payload_with_associations
+    event_least = EventName.create(name: "LeastEvent")
 
-    expected = ["event_most", "event_least"]
+    PayloadRequest.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name: associations[:event],
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      client_id: 1,
+                      key: "SHA2")
+    PayloadRequest.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name: event_least,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      client_id: 1,
+                      key: "SHA2")
+
+    expected = ["MostEvent", "LeastEvent"]
 
     assert_equal expected, EventName.most_to_least_received
   end

--- a/test/models/ip_test.rb
+++ b/test/models/ip_test.rb
@@ -14,4 +14,10 @@ class IpTest < Minitest::Test
 
     assert_equal "ip", PayloadRequest.first.ip.address
   end
+
+  def test_ip_payload_connection
+    ip = Ip.create
+
+    assert ip.respond_to?(:payload_requests)
+  end
 end

--- a/test/models/ip_test.rb
+++ b/test/models/ip_test.rb
@@ -10,8 +10,8 @@ class IpTest < Minitest::Test
   end
 
   def test_ip_payload_requests_relationship
-    aggregate_setup
+    standard_payload_with_associations
 
-    assert_equal "127.0.0.1", PayloadRequest.first.ip.address
+    assert_equal "ip", PayloadRequest.first.ip.address
   end
 end

--- a/test/models/referrers_test.rb
+++ b/test/models/referrers_test.rb
@@ -19,9 +19,15 @@ class ReferrerTest < Minitest::Test
   end
 
   def test_referrer_payload_relationship
-    aggregate_setup
+    standard_payload_with_associations
 
     assert_kind_of Referrer, PayloadRequest.first.referrer
+  end
+
+  def test_referrer_payload_connection
+    referrer = Referrer.create
+
+    assert referrer.respond_to?(:payload_requests)
   end
 
 end

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -16,27 +16,61 @@ class RequestTypeTest < Minitest::Test
     assert_equal 1, rt.errors.messages.length
   end
 
+  def test_request_type_payload_connection
+    request_type = RequestType.create
+
+    assert request_type.respond_to?(:payload_requests)
+  end
+
   def test_request_type_payload_request_relationship
-    aggregate_setup
+    standard_payload_with_associations
 
     rt =  RequestType.first
     pr = PayloadRequest.first
 
-    assert_equal 6, rt.payload_requests.count
-    assert_equal 30, rt.payload_requests.first.responded_in
-    assert_equal "GET", pr.request_type.verb
+    assert_equal 1, rt.payload_requests.count
+    assert_equal "MOST", pr.request_type.verb
   end
 
   def test_we_can_see_most_frequest_verbs
-    aggregate_setup
+    standard_payload_with_associations
+    standard_payload_with_associations
+    least_request_type = RequestType.create(verb: "LEAST")
+    PayloadRequest.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type: least_request_type,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      client_id: 1,
+                      key: "SHA2")
 
-    assert_equal "GET", RequestType.most_frequent_request_type.verb
+
+    assert_equal "MOST", RequestType.most_frequent_request_type.verb
   end
 
   def test_we_can_see_all_http_verbs
-    aggregate_setup
+    standard_payload_with_associations
+    standard_payload_with_associations
+    least_request_type = RequestType.create(verb: "LEAST")
+    PayloadRequest.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type: least_request_type,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      client_id: 1,
+                      key: "SHA2")
 
-    assert_equal ["GET", "PATCH", "POST"], RequestType.all_http_verbs.sort
+    assert_equal ["LEAST", "MOST"], RequestType.all_http_verbs.sort
   end
 
 end

--- a/test/models/resolution_test.rb
+++ b/test/models/resolution_test.rb
@@ -17,20 +17,37 @@ class ResolutionTest < Minitest::Test
     assert_equal 1, resolution.errors.messages.length
   end
 
+  def test_resolution_payload_connection
+    resolution = Resolution.create
+
+    assert resolution.respond_to?(:payload_requests)
+  end
+
   def test_resolution_payload_requests_relationship
-    aggregate_setup
+    associations = standard_payload_with_associations
     pr = PayloadRequest.first
 
-    assert_equal 6, @resolution_most.payload_requests.count
-    assert_equal 6, @resolution_least.payload_requests.count
-    assert_equal 1, @resolution_most.payload_requests.first.resolution_id
-    assert_equal 30, @resolution_most.payload_requests.first.responded_in
-    assert_equal "1080", pr.resolution.height
+    assert_equal 1, associations[:resolution].payload_requests.count
+
   end
 
   def test_resolution_list
-    aggregate_setup
+    standard_payload_with_associations
+    standard_payload_with_associations
+    other_resolution = Resolution.create(width: 2, height: 2)
+    PayloadRequest.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url_id: 1,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution: other_resolution,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      client_id: 100,
+                      key: "SHA2")
 
-    assert_equal ["1080 x 1920" , "1200 x 1600" ], Resolution.list_of_resolutions.sort
+    assert_equal ["1 x 1" , "2 x 2" ], Resolution.list_of_resolutions.sort
   end
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -16,22 +16,40 @@ class UrlTest < Minitest::Test
     assert_equal 1, url.errors.messages.length
   end
 
-  def test_url_payload_requests_relationship
-    aggregate_setup
+  def test_url_payload_connection
+    url = Url.create
 
-    url = Url.first
-    pr = PayloadRequest.first
-
-    assert_equal 2, url.payload_requests.count
-    assert_equal 1, url.payload_requests.first.event_name_id
-    assert_equal 45, url.payload_requests.first.responded_in
-    assert_equal "www.most.com", pr.url.address
+    assert url.respond_to?(:payload_requests)
   end
 
-  def test_it_sorts_by_requested
-    aggregate_setup
+  def test_url_payload_requests_relationship
+    associations = standard_payload_with_associations
 
-    assert_equal ["www.most.com", "www.least.com"], Url.most_to_least_requested
+    assert_equal 1, associations[:url].payload_requests.count
+    assert_equal "Client", associations[:url].payload_requests.first.client.identifier
+    assert_equal "www.client.com/most", associations[:payload_request].url.address
+  end
+
+
+  def test_it_sorts_by_requested
+    standard_payload_with_associations
+    standard_payload_with_associations
+    least_url = Url.create(address: "www.client.com/least")
+    PayloadRequest.create(requested_at: "2013-02-16 01:38:28 -0700",
+                      responded_in: 20,
+                      parameters: "[]",
+                      url: least_url,
+                      event_name_id: 1,
+                      request_type_id: 1,
+                      resolution_id: 1,
+                      referrer_id: 1,
+                      user_agent_id: 1,
+                      ip_id: 1,
+                      client_id: 100,
+                      key: "SHA2")
+
+    assert_equal ["www.client.com/most", "www.client.com/least"], Url.most_to_least_requested
+
   end
 
 
@@ -65,8 +83,8 @@ class UrlTest < Minitest::Test
     aggregate_setup
     url = Url.find_by(address: "www.most.com")
 
-
-    assert_equal ["Linux Chrome", "OSX Chrome", "Windows IE"], url.popular_agents.sort
+    assert_equal "Linux Chrome", url.popular_agents.sort.first
+    assert_equal 3, url.popular_agents.count
   end
 
   def test_it_can_find_calculate_response_time_stats_for_one_url

--- a/test/models/user_agent_test.rb
+++ b/test/models/user_agent_test.rb
@@ -4,9 +4,9 @@ class UserAgentTest < Minitest::Test
   include TestHelpers
 
   def test_it_creates_user_agent
-    ua = UserAgent.create(os: "osX", browser: "Chrome")
+    UserAgent.create(os: "osX", browser: "Chrome")
 
-    assert_equal "osX", ua.os
+    assert_equal 1, UserAgent.count
   end
 
   def test_it_invalidates_user_agent
@@ -16,14 +16,26 @@ class UserAgentTest < Minitest::Test
     assert_equal 2, ua.errors.messages.length
   end
 
-  def test_user_agent_payload_requests_relationship
-    aggregate_setup
-    ua = UserAgent.find_by(browser: "Chrome")
-    pr = PayloadRequest.first
+  def test_user_agent_payload_connection
+    user_agent = UserAgent.create
 
-    assert_equal 4, ua.payload_requests.count
-    assert_equal 2, ua.payload_requests.first.event_name_id
-    assert_equal 30, ua.payload_requests.first.responded_in
-    assert_equal "Chrome", pr.user_agent.browser
+    assert user_agent.respond_to?(:payload_requests)
+  end
+
+  def test_user_agent_attributes_are_accessible
+    ua = UserAgent.create(os: "osX", browser: "Chrome")
+
+    assert_equal "osX", ua.os
+    assert_equal "Chrome", ua.browser
+
+  end
+
+
+  def test_user_agent_payload_requests_relationship
+    associations = standard_payload_with_associations
+
+    assert_equal 1, associations[:user_agent].payload_requests.count
+    assert_equal "Client", associations[:user_agent].payload_requests.first.client.identifier
+
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,30 @@ module TestHelpers
     super
   end
 
+  def standard_payload_with_associations
+    @client = Client.create(identifier: "Client", root_url: "www.client.com")
+    event = EventName.create(name: "MostEvent")
+    referrer = Referrer.create(address: "www.MostReferrer.com")
+    request_type = RequestType.create(verb: "MOST")
+    resolution = Resolution.create(width: 1, height: 1)
+    url = Url.create(address: "www.client.com/most")
+    user_agent = UserAgent.create(os: "MostOS", browser: "MostBrowser")
+    ip = Ip.create(address: "ip")
+    payload_request = PayloadRequest.create(requested_at: "2013-02-16 21:38:28 -0700",
+                      responded_in: 10,
+                      parameters: "[]",
+                      url: url,
+                      event_name: event,
+                      request_type: request_type,
+                      resolution: resolution,
+                      referrer: referrer,
+                      user_agent: user_agent,
+                      ip: ip,
+                      client: @client,
+                      key: "SHA1")
+    {client: @client, event: event, referrer: referrer, request_type: request_type, resolution: resolution, url: url, user_agent: user_agent, payload_request: payload_request}
+  end
+
   def aggregate_setup
     @client = Client.create(identifier: "jumpstartlab", root_url: "http://jumpstartlab.com")
 
@@ -226,7 +250,7 @@ module TestHelpers
 
     PayloadRequest.create(url: Url.find_or_create_by({address: "www.relative.com/path"}),
                           requested_at: "2014-02-16 21:38:28 -0700",
-                          responded_in: 10, 
+                          responded_in: 10,
                           referrer: Referrer.find_or_create_by(address: "www.referrer.com"),
                           request_type: RequestType.find_or_create_by(verb: "GET"),
                           parameters: "[]",
@@ -239,7 +263,7 @@ module TestHelpers
 
     PayloadRequest.create(url: Url.find_or_create_by({address: "www.relative.com/list"}),
                           requested_at: "2014-02-16 21:38:28 -0700",
-                          responded_in: 10, 
+                          responded_in: 10,
                           referrer: Referrer.find_or_create_by(address: "www.referrer.com"),
                           request_type: RequestType.find_or_create_by(verb: "GET"),
                           parameters: "[]",
@@ -252,7 +276,7 @@ module TestHelpers
 
     PayloadRequest.create(url: Url.find_or_create_by({address: "www.relative.com/new"}),
                           requested_at: "2014-02-16 21:38:28 -0700",
-                          responded_in: 10, 
+                          responded_in: 10,
                           referrer: Referrer.find_or_create_by(address: "www.referrer.com"),
                           request_type: RequestType.find_or_create_by(verb: "GET"),
                           parameters: "[]",


### PR DESCRIPTION
Hey folks,
This is the redo redo of the redone tests.  Back to using the standard_payload_request setup for most model tests.  Then, for the most part, I added 1-2 additional payload requests on top of that one in each test in order to test the functionality related to sorting, listing, grouping, counting, etc. 

I kept a few uses of aggregate set up in here, because, frankly, I think it's a good choice for a number of these tests that are grouping and counting. 

Brian - with your additional feature tests, I think this should do it.  In any event, I don't think I can muster any more effort on this :)

Kerry 

